### PR TITLE
fix: security dependency remediation (1.4.1)

### DIFF
--- a/bot/commands/eightBallCommand.spec.ts
+++ b/bot/commands/eightBallCommand.spec.ts
@@ -6,10 +6,17 @@ import 'reflect-metadata';
 import { ChatClient, ChatUser } from '@twurple/chat';
 import { Container } from 'inversify';
 import winston from 'winston';
+import fs from 'fs';
+import axios from 'axios';
+import { WebSocket as MockWebSocket } from 'ws';
 import { mockChatClient, mockLogger } from '../../tests/common.mocks';
 import InjectionTypes from '../../dependency-management/types';
 import { ICommandHandler } from './iCommandHandler';
 import { EightBallCommand } from './eightBallCommand';
+
+jest.mock('ws', () => ({
+    WebSocket: jest.fn(),
+}));
 
 describe('Eight Ball Command Tests', () => {
     const channel = 'TestChannel';
@@ -36,169 +43,205 @@ describe('Eight Ball Command Tests', () => {
             .bind<ICommandHandler>(InjectionTypes.CommandHandlers)
             .to(EightBallCommand);
 
-        expectedChatClient = container
-            .get(ChatClient);
-
-        expectedLogger = container
-            .get<winston.Logger>(InjectionTypes.Logger);
+        expectedChatClient = container.get(ChatClient);
+        expectedLogger = container.get<winston.Logger>(InjectionTypes.Logger);
     });
 
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    function getSubject(): EightBallCommand {
+        return container
+            .getAll<ICommandHandler>(InjectionTypes.CommandHandlers)
+            .find(x => x.constructor.name === EightBallCommand.name) as EightBallCommand;
+    }
+
     describe(`Eightball Command`, () => {
-        it(`should say response in chat if a file that exists`, async () => {
-            // Arrange
+        it(`should say response in chat when the audio file is already cached`, async () => {
             const langCode = 'en';
             const response = 'TestResponse';
+            const subject = getSubject();
 
-            const subject: EightBallCommand = container
-                .getAll<ICommandHandler>(InjectionTypes.CommandHandlers)
-                .find(x => x.constructor.name === `${EightBallCommand.name}`) as EightBallCommand;
-
-            // eslint-disable-next-line dot-notation
             subject['responses'] = [response];
-
-            // eslint-disable-next-line dot-notation
-            subject['fileExists'] = jest.fn().mockReturnValue(false);
-
-            // eslint-disable-next-line dot-notation
+            // File is already cached - TTS should not be called
+            subject['fileExists'] = jest.fn().mockReturnValue(true);
             subject['broadcastAudio'] = jest.fn().mockResolvedValue(undefined);
 
-            // Act
             await subject.handle(channel, command, user, message, []);
 
-            // Assert
-            // eslint-disable-next-line dot-notation
             expect(subject['broadcastAudio'])
                 .toHaveBeenCalledWith(command, expect.anything(), langCode);
             expect(expectedChatClient.say)
                 .toHaveBeenCalledTimes(1);
-
             expect(expectedChatClient.say)
                 .toHaveBeenCalledWith(channel, response);
-
             expect(expectedLogger.info)
                 .toHaveBeenCalledWith(expect
                     .stringMatching(`(?=.*\\b${command}\\b)(?=.*\\b${channel}\\b)(?=.*\\b${user.displayName}\\b)(?=.*\\b${message}\\b)`));
         });
 
         it(`should generate a file if a file does not exist`, async () => {
-            // Arrange
             const langCode = 'en';
             const response = 'TestResponse';
+            const subject = getSubject();
 
-            const subject: EightBallCommand = container
-                .getAll<ICommandHandler>(InjectionTypes.CommandHandlers)
-                .find(x => x.constructor.name === `${EightBallCommand.name}`) as EightBallCommand;
-
-            // eslint-disable-next-line dot-notation
             subject['responses'] = [response];
-
-            // eslint-disable-next-line dot-notation
             subject['fileExists'] = jest.fn().mockReturnValue(false);
-
-            // eslint-disable-next-line dot-notation
             subject['broadcastAudio'] = jest.fn().mockResolvedValue(undefined);
-
-            // eslint-disable-next-line dot-notation
             subject['getAudioFromGoogleTTS'] = jest.fn().mockResolvedValue('MTIzNDU2Nzg=');
-
-            // eslint-disable-next-line dot-notation
             subject['generateFile'] = jest.fn().mockReturnValue(undefined);
 
-            // Act
             await subject.handle(channel, command, user, message, []);
 
-            // Assert
-            // eslint-disable-next-line dot-notation
             expect(subject['broadcastAudio'])
                 .toHaveBeenCalledWith(command, expect.anything(), langCode);
             expect(expectedChatClient.say)
                 .toHaveBeenCalledTimes(1);
-
             expect(expectedChatClient.say)
                 .toHaveBeenCalledWith(channel, response);
-
             expect(expectedLogger.info)
                 .toHaveBeenNthCalledWith(1, expect.stringContaining('Generated file'));
             expect(expectedLogger.info)
                 .toHaveBeenNthCalledWith(1, expect.stringContaining('local-cache/audio/8ball'));
             expect(expectedLogger.info)
                 .toHaveBeenNthCalledWith(1, expect.stringContaining(EightBallCommand.name));
-
             expect(expectedLogger.info)
                 .toHaveBeenNthCalledWith(2, expect
                     .stringMatching(`(?=.*\\b${command}\\b)(?=.*\\b${channel}\\b)(?=.*\\b${user.displayName}\\b)(?=.*\\b${message}\\b)`));
         });
 
         it(`should log and do nothing when an exception is thrown`, async () => {
-            // Arrange
-            const langCode = 'en';
             const response = 'TestResponse';
             const exception = new Error('TestExceptionMessage');
+            const subject = getSubject();
 
-            const subject: EightBallCommand = container
-                .getAll<ICommandHandler>(InjectionTypes.CommandHandlers)
-                .find(x => x.constructor.name === `${EightBallCommand.name}`) as EightBallCommand;
-
-            // eslint-disable-next-line dot-notation
             subject['responses'] = [response];
-
-            // eslint-disable-next-line dot-notation
             subject['fileExists'] = jest.fn(() => { throw exception; });
 
-            // Act
             await subject.handle(channel, command, user, message, []);
 
-            // Assert
             expect(expectedChatClient.say).not.toHaveBeenCalled();
-
             expect(expectedLogger.error)
                 .toHaveBeenCalledWith(expect.stringContaining('Failed'), exception);
         });
     });
 
     describe(`Utilities - fileExists`, () => {
-        jest.mock('fs', () => ({
-            existsSync: jest.fn().mockReturnValue(true),
-        }));
+        it(`should return true when the file exists`, () => {
+            const subject = getSubject();
+            const spy = jest.spyOn(fs, 'existsSync').mockReturnValue(true);
 
-        it(`should return the existance of a file`, () => {
-            // Arrange
-            jest.mock('fs', () => ({
-                existsSync: jest.fn().mockReturnValue(true),
-            }));
+            const result = subject['fileExists']('TestFilePath');
 
-            const subject: EightBallCommand = container
-                .getAll<ICommandHandler>(InjectionTypes.CommandHandlers)
-                .find(x => x.constructor.name === `${EightBallCommand.name}`) as EightBallCommand;
-
-            // Act
-            // eslint-disable-next-line dot-notation
-            const result = subject['fileExists'].call('TestFilePath');
-
-            // Assert
             expect(result).toBe(true);
+            expect(spy).toHaveBeenCalledWith('TestFilePath');
+        });
+
+        it(`should return false when the file does not exist`, () => {
+            const subject = getSubject();
+            const spy = jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+            const result = subject['fileExists']('TestFilePath');
+
+            expect(result).toBe(false);
+            expect(spy).toHaveBeenCalledWith('TestFilePath');
         });
     });
 
     describe(`Utilities - getAudioFromGoogleTTS`, () => {
-        it(`should connect to GoogleTTS and send message`, () => {
-            expect(0).toBe(1);
+        it(`should POST to Google Translate and return base64 audio`, async () => {
+            const subject = getSubject();
+            const audioBase64 = 'SGVsbG8gV29ybGQ=';
+            const innerPayload = JSON.stringify([audioBase64]);
+            const outerData = JSON.stringify([[null, null, innerPayload]]);
+            const mockResponse = { data: ")]}'\n" + outerData };
+
+            const postSpy = jest.spyOn(axios, 'post').mockResolvedValue(mockResponse);
+
+            const result = await subject['getAudioFromGoogleTTS']('Hello World');
+
+            expect(postSpy).toHaveBeenCalledWith(
+                'https://translate.google.com/_/TranslateWebserverUi/data/batchexecute',
+                expect.stringContaining('f.req='),
+                expect.objectContaining({
+                    timeout: 20000,
+                    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                }),
+            );
+            expect(result).toBe(audioBase64);
+        });
+
+        it(`should throw when Google TTS returns no audio data`, async () => {
+            const subject = getSubject();
+            const innerPayload = JSON.stringify([null]);
+            const outerData = JSON.stringify([[null, null, innerPayload]]);
+            const mockResponse = { data: ")]}'\n" + outerData };
+
+            jest.spyOn(axios, 'post').mockResolvedValue(mockResponse);
+
+            await expect(subject['getAudioFromGoogleTTS']('Hello World'))
+                .rejects.toThrow('Google TTS returned no audio data');
         });
     });
 
     describe(`Utilities - generateFile`, () => {
-        it(`should make directories`, () => {
-            expect(0).toBe(1);
+        it(`should create directories and write file when neither exist`, () => {
+            const subject = getSubject();
+            const buffer = Buffer.from('test');
+            const rootPath = 'local-cache/audio/8ball';
+            const filePath = `${rootPath}/abc123.en.mp3`;
+
+            jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+            const mkdirSpy = jest.spyOn(fs, 'mkdirSync').mockReturnValue(undefined);
+            const writeSpy = jest.spyOn(fs, 'writeFileSync').mockImplementation(() => undefined);
+
+            subject['generateFile'](buffer, rootPath, filePath);
+
+            expect(mkdirSpy).toHaveBeenCalledWith(rootPath, { recursive: true });
+            expect(writeSpy).toHaveBeenCalledWith(filePath, buffer, { encoding: 'base64' });
         });
 
-        it(`should write file`, () => {
-            expect(0).toBe(1);
+        it(`should write file without creating directories when root path already exists`, () => {
+            const subject = getSubject();
+            const buffer = Buffer.from('test');
+            const rootPath = 'local-cache/audio/8ball';
+            const filePath = `${rootPath}/abc123.en.mp3`;
+
+            // First call is filePath (does not exist), second is rootPath (exists)
+            jest.spyOn(fs, 'existsSync')
+                .mockReturnValueOnce(false)
+                .mockReturnValueOnce(true);
+            const mkdirSpy = jest.spyOn(fs, 'mkdirSync').mockReturnValue(undefined);
+            const writeSpy = jest.spyOn(fs, 'writeFileSync').mockImplementation(() => undefined);
+
+            subject['generateFile'](buffer, rootPath, filePath);
+
+            expect(mkdirSpy).not.toHaveBeenCalled();
+            expect(writeSpy).toHaveBeenCalledWith(filePath, buffer, { encoding: 'base64' });
         });
     });
 
     describe(`Utilities - broadcastAudio`, () => {
-        it(`should connect to websocket and send message`, () => {
-            expect(0).toBe(1);
+        it(`should connect to websocket and send a play message`, () => {
+            const subject = getSubject();
+            const mockSend = jest.fn();
+            let capturedOnOpen: (() => void) | null = null;
+
+            jest.mocked(MockWebSocket).mockImplementation(() => ({
+                get onopen() { return capturedOnOpen; },
+                set onopen(handler: () => void) {
+                    capturedOnOpen = handler;
+                    handler();
+                },
+                send: mockSend,
+            }) as any);
+
+            subject['broadcastAudio']('TestCommand', 'abc123', 'en');
+
+            expect(mockSend).toHaveBeenCalledWith(
+                expect.stringContaining('!play abc123 en'),
+            );
         });
     });
 });

--- a/bot/commands/eightBallCommand.ts
+++ b/bot/commands/eightBallCommand.ts
@@ -2,7 +2,7 @@ import { ChatClient, ChatUser } from '@twurple/chat';
 import { inject, injectable } from 'inversify';
 import winston from 'winston';
 import fs from 'fs';
-import { getAudioBase64 } from 'google-tts-api';
+import axios from 'axios';
 import md5 from 'md5';
 import { WebSocket } from 'ws';
 import { ICommandHandler, OnlineState } from './iCommandHandler';
@@ -124,12 +124,21 @@ export class EightBallCommand implements ICommandHandler {
     }
 
     private async getAudioFromGoogleTTS(content: string): Promise<string> {
-        return getAudioBase64(content, {
-            lang: 'en',
-            slow: false,
-            host: 'https://translate.google.com',
-            timeout: 20000,
-        });
+        const payload = `f.req=${encodeURIComponent(
+            JSON.stringify([[['jQ1olc', JSON.stringify([content, 'en', null, 'null']), null, 'generic']]]),
+        )}`;
+        const res = await axios.post(
+            'https://translate.google.com/_/TranslateWebserverUi/data/batchexecute',
+            payload,
+            {
+                timeout: 20000,
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            },
+        );
+        const outer = JSON.parse(res.data.slice(5));
+        const audio = JSON.parse(outer[0][2])?.[0];
+        if (!audio) throw new Error('Google TTS returned no audio data');
+        return audio;
     }
 
     private generateFile(buffer: Buffer, rootPath: string, filePath: string) {

--- a/bot/overlay/overlay.server.ts
+++ b/bot/overlay/overlay.server.ts
@@ -24,7 +24,7 @@ export default class OverlayServer implements IOverlayServer {
         @inject(InjectionTypes.Logger) private logger: winston.Logger,
     ) {
         this.host = environment.twitchBot.overlay.host;
-        this.port = environment.twitchBot.overlay.port + 1;
+        this.port = environment.twitchBot.overlay.port;
     }
 
     configure(): IOverlayServer {

--- a/bot/overlay/socket.server.spec.ts
+++ b/bot/overlay/socket.server.spec.ts
@@ -1,0 +1,265 @@
+import 'reflect-metadata';
+import { Container } from 'inversify';
+import winston from 'winston';
+import { Server } from 'ws';
+import { mockLogger } from '../../tests/common.mocks';
+import InjectionTypes from '../../dependency-management/types';
+import SocketServer from './socket.server';
+
+jest.mock('ws', () => ({
+    Server: jest.fn(),
+    WebSocket: jest.fn(),
+}));
+
+jest.mock('../../configurations/environment', () => ({
+    __esModule: true,
+    default: {
+        twitchBot: {
+            websocket: {
+                host: 'localhost',
+                port: 8080,
+            },
+        },
+    },
+}));
+
+describe('SocketServer', () => {
+    let serverHandlers: Record<string, Function>;
+    let mockServerInstance: { on: jest.Mock };
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        serverHandlers = {};
+        mockServerInstance = {
+            on: jest.fn((event: string, handler: Function) => {
+                serverHandlers[event] = handler;
+            }),
+        };
+
+        jest.mocked(Server).mockImplementation(((_options: unknown, callback?: () => void) => {
+            if (callback) callback();
+            return mockServerInstance;
+        }) as any);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    function buildSubject(): SocketServer {
+        const container = new Container();
+        container.bind<winston.Logger>(InjectionTypes.Logger).toConstantValue(mockLogger);
+        container.bind(SocketServer).to(SocketServer);
+        return container.get(SocketServer);
+    }
+
+    function createMockWebSocket() {
+        const wsHandlers: Record<string, Function> = {};
+        return {
+            on: jest.fn((event: string, handler: Function) => {
+                wsHandlers[event] = handler;
+            }),
+            send: jest.fn(),
+            handlers: wsHandlers,
+        };
+    }
+
+    describe('startServer()', () => {
+        it('starts the server on the configured port without modification', () => {
+            // Arrange
+            const subject = buildSubject();
+
+            // Act
+            subject.startServer();
+
+            // Assert
+            expect(jest.mocked(Server)).toHaveBeenCalledWith(
+                expect.objectContaining({ port: 8080 }),
+                expect.any(Function),
+            );
+        });
+
+        it('starts the server on the configured host', () => {
+            // Arrange
+            const subject = buildSubject();
+
+            // Act
+            subject.startServer();
+
+            // Assert
+            expect(jest.mocked(Server)).toHaveBeenCalledWith(
+                expect.objectContaining({ host: 'localhost' }),
+                expect.any(Function),
+            );
+        });
+
+        it('logs startup message containing the configured port', () => {
+            // Arrange
+            const subject = buildSubject();
+
+            // Act
+            subject.startServer();
+
+            // Assert
+            expect(mockLogger.info).toHaveBeenCalledWith(
+                expect.stringContaining('8080'),
+            );
+        });
+    });
+
+    describe('connection handling', () => {
+        it('tracks connected user so they receive broadcast messages', () => {
+            // Arrange
+            const subject = buildSubject();
+            subject.startServer();
+
+            const mockWs1 = createMockWebSocket();
+            const mockWs2 = createMockWebSocket();
+            serverHandlers['connection'](mockWs1);
+            serverHandlers['connection'](mockWs2);
+
+            // Act
+            const msg = Buffer.from(JSON.stringify({ sender: 'test', body: 'hello' }));
+            mockWs1.handlers['message'](msg, false);
+
+            // Assert
+            expect(mockWs2.send).toHaveBeenCalledWith(expect.stringContaining('hello'));
+        });
+
+        it('removes user on close so they no longer receive broadcast messages', () => {
+            // Arrange
+            const subject = buildSubject();
+            subject.startServer();
+
+            const mockWs1 = createMockWebSocket();
+            const mockWs2 = createMockWebSocket();
+            serverHandlers['connection'](mockWs1);
+            serverHandlers['connection'](mockWs2);
+
+            // Act
+            mockWs1.handlers['close'](1000, Buffer.from('normal'));
+
+            // Assert - probe with a message; mockWs1 should not receive it
+            const msg = Buffer.from(JSON.stringify({ sender: 'test', body: 'hello' }));
+            mockWs2.handlers['message'](msg, false);
+
+            expect(mockWs1.send).not.toHaveBeenCalled();
+        });
+
+        it('logs when a connection closes', () => {
+            // Arrange
+            const subject = buildSubject();
+            subject.startServer();
+
+            const mockWs = createMockWebSocket();
+            serverHandlers['connection'](mockWs);
+
+            // Act
+            mockWs.handlers['close'](1000, Buffer.from('normal'));
+
+            // Assert
+            expect(mockLogger.info).toHaveBeenCalledWith(
+                expect.stringContaining('closed'),
+            );
+        });
+    });
+
+    describe('message broadcasting', () => {
+        it('broadcasts a valid message to all connected users', () => {
+            // Arrange
+            const subject = buildSubject();
+            subject.startServer();
+
+            const mockWs1 = createMockWebSocket();
+            const mockWs2 = createMockWebSocket();
+            serverHandlers['connection'](mockWs1);
+            serverHandlers['connection'](mockWs2);
+
+            // Act
+            const msg = Buffer.from(JSON.stringify({ sender: 'TestSender', body: 'TestBody' }));
+            mockWs1.handlers['message'](msg, false);
+
+            // Assert
+            expect(mockWs1.send).toHaveBeenCalledWith(expect.stringContaining('TestBody'));
+            expect(mockWs2.send).toHaveBeenCalledWith(expect.stringContaining('TestBody'));
+        });
+
+        it('logs error and does not broadcast when message is missing required fields', () => {
+            // Arrange
+            const subject = buildSubject();
+            subject.startServer();
+
+            const mockWs = createMockWebSocket();
+            serverHandlers['connection'](mockWs);
+
+            // Act
+            const msg = Buffer.from(JSON.stringify({ foo: 'bar' }));
+            mockWs.handlers['message'](msg, false);
+
+            // Assert
+            expect(mockLogger.error).toHaveBeenCalledWith(
+                expect.stringContaining('Invalid message'),
+            );
+            expect(mockWs.send).not.toHaveBeenCalled();
+        });
+
+        it('logs error when message cannot be parsed as JSON', () => {
+            // Arrange
+            const subject = buildSubject();
+            subject.startServer();
+
+            const mockWs = createMockWebSocket();
+            serverHandlers['connection'](mockWs);
+
+            // Act
+            const msg = Buffer.from('not valid json {');
+            mockWs.handlers['message'](msg, false);
+
+            // Assert
+            expect(mockLogger.error).toHaveBeenCalledWith(
+                expect.stringContaining('Error'),
+                expect.any(Error),
+            );
+        });
+    });
+
+    describe('error handling', () => {
+        it('logs server-level errors', () => {
+            // Arrange
+            const subject = buildSubject();
+            subject.startServer();
+
+            const error = new Error('Server error');
+
+            // Act
+            serverHandlers['error'](error);
+
+            // Assert
+            expect(mockLogger.error).toHaveBeenCalledWith(
+                expect.stringContaining('Error'),
+                error,
+            );
+        });
+
+        it('logs websocket-level errors', () => {
+            // Arrange
+            const subject = buildSubject();
+            subject.startServer();
+
+            const mockWs = createMockWebSocket();
+            serverHandlers['connection'](mockWs);
+
+            const error = new Error('WebSocket error');
+
+            // Act
+            mockWs.handlers['error'](error);
+
+            // Assert
+            expect(mockLogger.error).toHaveBeenCalledWith(
+                expect.stringContaining('Error'),
+                error,
+            );
+        });
+    });
+});

--- a/bot/overlay/socket.server.ts
+++ b/bot/overlay/socket.server.ts
@@ -19,11 +19,11 @@ export interface ISocketServer {
 @injectable()
 export default class SocketServer implements ISocketServer {
     /** Instance of the Web Socket server */
-    private server: Server;
+    private server: Server | undefined;
     /** Configured Web Socket Host */
-    private host: string;
+    private readonly host: string;
     /** Configured Web Socket Port */
-    private port: number;
+    private readonly port: number;
     /** Connected Web Socket Users */
     private users: Set<UserRef> = new Set();
 

--- a/bot/overlay/socket.server.ts
+++ b/bot/overlay/socket.server.ts
@@ -31,7 +31,7 @@ export default class SocketServer implements ISocketServer {
         @inject(InjectionTypes.Logger) private logger: winston.Logger,
     ) {
         this.host = environment.twitchBot.websocket.host;
-        this.port = environment.twitchBot.websocket.port + 1;
+        this.port = environment.twitchBot.websocket.port;
     }
 
     /** Initializes and starts the server */

--- a/configurations/environment.ts
+++ b/configurations/environment.ts
@@ -26,12 +26,12 @@ const environment = {
         },
         /** OBS Overlay Web server */
         overlay: {
-            host: process.env.TWITCH_OVERLAY_HOST,
+            host: String(process.env.TWITCH_OVERLAY_HOST),
             port: Number(process.env.TWITCH_OVERLAY_PORT),
         },
         /** Web Socket server */
         websocket: {
-            host: process.env.TWITCH_WEBSOCKET_HOST,
+            host: String(process.env.TWITCH_WEBSOCKET_HOST),
             port: Number(process.env.TWITCH_WEBSOCKET_PORT),
         },
         /** Authentication Web server */

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "tedious": "18.1.0",
         "ts-node": "10.9.2",
         "typescript": "5.4.5",
-        "uuid": "9.0.1",
+        "uuid": "11.1.1",
         "winston": "3.13.0",
         "winston-daily-rotate-file": "5.0.0",
         "ws": "8.20.1"
@@ -1915,6 +1915,20 @@
         "tedious": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@sequelize/core/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -9992,15 +10006,16 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stream-assist-bot",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stream-assist-bot",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "GPLv3",
       "dependencies": {
         "@sequelize/core": "7.0.0-alpha.37",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7105,9 +7105,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stream-assist-bot",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stream-assist-bot",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "GPLv3",
       "dependencies": {
         "@sequelize/core": "7.0.0-alpha.37",
@@ -36,7 +36,7 @@
         "uuid": "9.0.1",
         "winston": "3.13.0",
         "winston-daily-rotate-file": "5.0.0",
-        "ws": "8.16.0"
+        "ws": "8.20.1"
       },
       "devDependencies": {
         "@types/express": "^5.0.6",
@@ -1159,10 +1159,11 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1204,10 +1205,11 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3299,15 +3301,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/braces": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
@@ -4107,6 +4100,17 @@
         "node": ">=14"
       }
     },
+    "node_modules/editorconfig/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/editorconfig/node_modules/minimatch": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
@@ -4545,10 +4549,11 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4626,10 +4631,11 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5426,10 +5432,11 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -6875,12 +6882,13 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/js-md4": {
@@ -7361,6 +7369,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/minimist": {
@@ -7957,9 +7976,10 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -8862,9 +8882,10 @@
       }
     },
     "node_modules/sequelize-typescript/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -9463,10 +9484,11 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -10229,9 +10251,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "dayjs": "1.11.10",
         "dotenv": "16.4.5",
         "express": "^5.2.1",
-        "google-tts-api": "2.0.2",
         "https": "1.0.0",
         "inversify": "6.0.2",
         "md5": "2.3.0",
@@ -5528,22 +5527,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/google-tts-api": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/google-tts-api/-/google-tts-api-2.0.2.tgz",
-      "integrity": "sha512-MkQYbBJEdom8hJpfEVDfD3tpBtkz0X59C+FNsoRhbnCiFjZRnzyurGQ5OrAr3xkigII56/jmk0JNwZsp450G+Q==",
-      "dependencies": {
-        "axios": "^0.21.0"
-      }
-    },
-    "node_modules/google-tts-api/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/gopd": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-assist-bot",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Twitch Bot for stream assistance, command interpretation, and additional processes.",
   "main": "app.ts",
   "module": "module",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "tedious": "18.1.0",
     "ts-node": "10.9.2",
     "typescript": "5.4.5",
-    "uuid": "9.0.1",
+    "uuid": "11.1.1",
     "winston": "3.13.0",
     "winston-daily-rotate-file": "5.0.0",
     "ws": "8.20.1"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "overrides": {
     "brace-expansion": "1.1.13",
     "js-cookie": "3.0.7",
+    "lodash": "4.18.1",
     "picomatch": "2.3.2"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "uuid": "9.0.1",
     "winston": "3.13.0",
     "winston-daily-rotate-file": "5.0.0",
-    "ws": "8.16.0"
+    "ws": "8.20.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.6",
@@ -51,6 +51,11 @@
     "sequelize-cli": "6.6.2",
     "supertest": "^7.2.2",
     "ts-jest": "29.1.2"
+  },
+  "overrides": {
+    "brace-expansion": "1.1.13",
+    "js-cookie": "3.0.7",
+    "picomatch": "2.3.2"
   },
   "scripts": {
     "start": "ts-node app.ts",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "dayjs": "1.11.10",
     "dotenv": "16.4.5",
     "express": "^5.2.1",
-    "google-tts-api": "2.0.2",
     "https": "1.0.0",
     "inversify": "6.0.2",
     "md5": "2.3.0",


### PR DESCRIPTION
## Summary

- Bumps `ws` from 8.16.0 to 8.20.1 (CVE-2026-45736)
- Bumps `uuid` from 9.0.1 to 11.1.1 (CVE-2026-41907)
- Replaces abandoned `google-tts-api` with direct axios implementation,
  eliminating 17 CVEs from the embedded axios 0.21.4 transitive dependency
- Adds npm overrides for transitive vulnerabilities: `brace-expansion`
  1.1.13, `js-cookie` 3.0.7, `lodash` 4.18.1, `picomatch` 2.3.2
- Fixes a latent bug in `EightBallCommand` where a null TTS response
  would return null instead of throwing
- Fixes broken and stub tests in `eightBallCommand.spec.ts`
- Adds `socket.server.spec.ts` with a port-assignment guard test to
  prevent recurrence of the AI-introduced port+1 regression from PR #90
- Marks `host` and `port` as `readonly` in `SocketServer`

## Remaining open item

`lodash` is a transitive dependency of the sequelize packages. The
override to 4.18.1 resolves the CVEs. No direct lodash usage exists
in application code.

## Test plan

- [x] `npm test` passes cleanly
- [x] `!8ball` command tested live - TTS generates, audio broadcasts correctly
- [ ] Dependabot alerts clear after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)