### PR TITLE
feat(database): route sequelize sql logging to dedicated log file

### DIFF
--- a/database/database.ts
+++ b/database/database.ts
@@ -17,6 +17,7 @@ import {
     Subscribers,
     RaidEvent,
 } from '.';
+import sqlLogger from '../logger/sql-logger';
 import environment from '../configurations/environment';
 
 /**
@@ -41,7 +42,7 @@ const pgConfig: SequelizeOptions = {
         acquire: 30000,
         idle: 10000,
     },
-    logging: false,
+    logging: (sql: string) => sqlLogger.debug(sql),
     models: [
         BanEvent,
         ChannelPointRedeem,
@@ -79,7 +80,9 @@ export default class Database {
     }
 
     async sync(): Promise<void> {
-        await this.sequelize.sync({ logging: false })
+        await this.sequelize
+            // sync logging has no diagnostic value
+            .sync({ logging: false })
             .then(obj => this.logger.info('DB Sync completed successfully'))
             .catch((error: any) => this.logger.error('**DB Sync Failed**:', error));
     }

--- a/logger/sql-logger.ts
+++ b/logger/sql-logger.ts
@@ -1,0 +1,26 @@
+import winston from 'winston';
+import DailyRotateFile from 'winston-daily-rotate-file';
+
+const sqlTransport: DailyRotateFile = new DailyRotateFile({
+    level: 'debug',
+    filename: './logs/%DATE%-sql.log',
+    datePattern: 'YYYY-MM-DD',
+    zippedArchive: false,
+});
+
+const sqlLogger = winston.createLogger({
+    level: 'debug',
+    format: winston.format.combine(
+        winston.format.timestamp({
+            format: 'YYYY-MM-DD HH:mm:ss',
+        }),
+        winston.format.errors({ stack: true }),
+        winston.format.splat(),
+        winston.format.json(),
+    ),
+    transports: [
+        sqlTransport,
+    ],
+});
+
+export default sqlLogger;


### PR DESCRIPTION
* adds logger/sql-logger.ts with dedicated DailyRotateFile transport
* wires sql logger into sequelize logging callback in database.ts
* keeps sql output out of main application logs