### PR TITLE
Feature/command rbac update

### DIFF
--- a/bot/commands/DivideByZeroCommand.ts
+++ b/bot/commands/DivideByZeroCommand.ts
@@ -10,6 +10,8 @@ export class DivideByZeroCommand implements ICommandHandler {
     timeout: number = 20;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = false;
     viewer: boolean = false;

--- a/bot/commands/aboutCommand.ts
+++ b/bot/commands/aboutCommand.ts
@@ -10,6 +10,8 @@ export class AboutCommand implements ICommandHandler {
     timeout: number = 5;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = true;
     viewer: boolean = true;

--- a/bot/commands/accountAgeCommand.ts
+++ b/bot/commands/accountAgeCommand.ts
@@ -12,6 +12,8 @@ export class AccountAgeCommand implements ICommandHandler {
     timeout: number = 5;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = true;
     viewer: boolean = false;

--- a/bot/commands/brainCommand.ts
+++ b/bot/commands/brainCommand.ts
@@ -11,6 +11,8 @@ export default class BrainCommand implements ICommandHandler {
     timeout: number = 5;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = true;
     viewer: boolean = false;

--- a/bot/commands/countExhaustCommand.ts
+++ b/bot/commands/countExhaustCommand.ts
@@ -11,6 +11,8 @@ export class CountExhaustCommand implements ICommandHandler {
     timeout: number = 10;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = false;
     viewer: boolean = false;

--- a/bot/commands/cuddleCommand.ts
+++ b/bot/commands/cuddleCommand.ts
@@ -11,6 +11,8 @@ export class CuddleCommand implements ICommandHandler {
     timeout: number = 30;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = true;
     viewer: boolean = true;

--- a/bot/commands/deathCommands.ts
+++ b/bot/commands/deathCommands.ts
@@ -22,6 +22,8 @@ export class DeathCommand implements ICommandHandler {
     timeout: number = 5;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = true;
     viewer: boolean = false;
@@ -85,6 +87,8 @@ export class DeathCountCommand implements ICommandHandler {
     timeout: number = 20;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = true;
     viewer: boolean = false;
@@ -121,6 +125,8 @@ export class LastDeathCountCommmand implements ICommandHandler {
     timeout: number = 30;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = true;
     viewer: boolean = false;

--- a/bot/commands/diceCommand.ts
+++ b/bot/commands/diceCommand.ts
@@ -15,6 +15,8 @@ export class DiceCommand implements ICommandHandler {
     timeout: number = 5;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = true;
     viewer: boolean = false;

--- a/bot/commands/drinkCommand.ts
+++ b/bot/commands/drinkCommand.ts
@@ -10,6 +10,8 @@ export class DrinkCommand implements ICommandHandler {
     timeout: number = 5;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = true;
     viewer: boolean = false;

--- a/bot/commands/eightBallCommand.ts
+++ b/bot/commands/eightBallCommand.ts
@@ -76,6 +76,8 @@ export class EightBallCommand implements ICommandHandler {
     timeout: number = 30;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = true;
     viewer: boolean = true;

--- a/bot/commands/fallCommand.ts
+++ b/bot/commands/fallCommand.ts
@@ -10,6 +10,8 @@ export class FallCommand implements ICommandHandler {
     timeout: number = 5;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = false;
     viewer: boolean = false;

--- a/bot/commands/followAgeCommand.ts
+++ b/bot/commands/followAgeCommand.ts
@@ -13,6 +13,8 @@ export class FollowAgeCommand implements ICommandHandler {
     timeout: number = 10;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = true;
     viewer: boolean = false;

--- a/bot/commands/helpCommand.ts
+++ b/bot/commands/helpCommand.ts
@@ -10,6 +10,8 @@ export class HelpCommand implements ICommandHandler {
     timeout: number = 15;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = true;
     viewer: boolean = true;

--- a/bot/commands/hugCommand.ts
+++ b/bot/commands/hugCommand.ts
@@ -11,6 +11,8 @@ export class HugCommand implements ICommandHandler {
     timeout: number = 30;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = true;
     viewer: boolean = true;

--- a/bot/commands/iCommandHandler.ts
+++ b/bot/commands/iCommandHandler.ts
@@ -12,6 +12,8 @@ export interface ICommandHandler {
     timeout: number;
     mod: boolean;
     vip: boolean;
+    artist: boolean;
+    founder: boolean;
     subscriber: boolean;
     follower: boolean;
     viewer: boolean;

--- a/bot/commands/lastRaidCommand.ts
+++ b/bot/commands/lastRaidCommand.ts
@@ -19,6 +19,8 @@ export class LastRaidCommand implements ICommandHandler {
     timeout: number = 5;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = false;
     viewer: boolean = false;

--- a/bot/commands/lastSubCommand.ts
+++ b/bot/commands/lastSubCommand.ts
@@ -23,6 +23,8 @@ export class LastSubCommand implements ICommandHandler {
     timeout: number = 30;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = false;
     viewer: boolean = false;

--- a/bot/commands/lurkCommands.ts
+++ b/bot/commands/lurkCommands.ts
@@ -11,6 +11,8 @@ export class LurkCommand implements ICommandHandler {
     timeout: number = 5;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = true;
     viewer: boolean = true;
@@ -43,6 +45,8 @@ export class UnLurkCommand implements ICommandHandler {
     timeout: number = 5;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = true;
     viewer: boolean = true;
@@ -80,6 +84,8 @@ export class WhoIsLurkingCommand implements ICommandHandler {
     timeout: number = 5;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = false;
     subscriber: boolean = false;
     follower: boolean = false;
     viewer: boolean = false;

--- a/bot/commands/shoutOutCommand.ts
+++ b/bot/commands/shoutOutCommand.ts
@@ -20,6 +20,8 @@ export class ShoutOutCommand implements ICommandHandler {
     timeout: number = 30;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = false;
     subscriber: boolean = false;
     follower: boolean = false;
     viewer: boolean = false;

--- a/bot/commands/socialsCommand.ts
+++ b/bot/commands/socialsCommand.ts
@@ -11,6 +11,8 @@ export class SocialsCommand implements ICommandHandler {
     timeout: number = 30;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = false;
     viewer: boolean = false;

--- a/bot/commands/throwCommand.ts
+++ b/bot/commands/throwCommand.ts
@@ -10,6 +10,8 @@ export default class ThrowCommand implements ICommandHandler {
     timeout: number = 5;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = true;
     viewer: boolean = false;

--- a/bot/commands/upTimeCommand.ts
+++ b/bot/commands/upTimeCommand.ts
@@ -15,6 +15,8 @@ export class UpTimeCommand implements ICommandHandler {
     timeout: number = 5;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = true;
     viewer: boolean = true;

--- a/bot/commands/wishListCommand.ts
+++ b/bot/commands/wishListCommand.ts
@@ -17,6 +17,8 @@ export class WishListCommand implements ICommandHandler {
     timeout: number = 300;
     mod: boolean = true;
     vip: boolean = true;
+    artist: boolean = false;
+    founder: boolean = true;
     subscriber: boolean = true;
     follower: boolean = true;
     viewer: boolean = true;

--- a/bot/handlers/message.handler.ts
+++ b/bot/handlers/message.handler.ts
@@ -117,7 +117,7 @@ export class MessageHandler {
         }
     }
 
-    private async isAuthorized(user: ChatUser, isFollower: boolean, command: ICommandHandler): Promise<boolean> {
+    private isAuthorized(user: ChatUser, isFollower: boolean, command: ICommandHandler): boolean {
         if (command.viewer) {
             return true;
         }
@@ -130,15 +130,23 @@ export class MessageHandler {
             return true;
         }
 
-        if (user.isSubscriber && command.subscriber) {
-            return true;
-        }
-
         if (user.isVip && command.vip) {
             return true;
         }
 
-        return isFollower;
+        if (command.artist && user.isArtist) {
+            return true;
+        }
+
+        if (command.founder && user.isFounder) {
+            return true;
+        }
+
+        if (user.isSubscriber && command.subscriber) {
+            return true;
+        }
+
+        return command.follower && (isFollower || user.isSubscriber || user.isFounder);
     }
 
     private timeoutPeriod(user: ChatUser, command: ICommandHandler): number {
@@ -146,7 +154,7 @@ export class MessageHandler {
             return 0;
         }
 
-        return user.isFounder || user.isMod || user.isSubscriber || user.isVip
+        return user.isFounder || user.isMod || user.isSubscriber || user.isVip || user.isArtist
             ? command.timeout / 2
             : command.timeout;
     }

--- a/bot/handlers/message.handler.ts
+++ b/bot/handlers/message.handler.ts
@@ -146,7 +146,7 @@ export class MessageHandler {
             return true;
         }
 
-        return command.follower && (isFollower || user.isSubscriber || user.isFounder);
+        return command.follower && (isFollower || user.isSubscriber);
     }
 
     private timeoutPeriod(user: ChatUser, command: ICommandHandler): number {

--- a/docs/command-system.md
+++ b/docs/command-system.md
@@ -1,0 +1,169 @@
+# Command System
+
+## Overview
+
+Commands are discrete units of chat functionality. Each command is a class implementing `ICommandHandler`, registered in the Inversify DI container, and discovered automatically by `MessageHandler` at runtime.
+
+`MessageHandler` (`bot/handlers/message.handler.ts`) is responsible for:
+1. Matching the incoming chat message against each command's `exp` pattern
+2. Checking whether the stream is live (vs offline) against the command's `restriction`
+3. Resolving whether the sending user holds a role that satisfies the command's permission flags
+4. Enforcing the command cooldown
+
+---
+
+## The `ICommandHandler` Interface
+
+```typescript
+export interface ICommandHandler {
+    exp: RegExp;
+    timeout: number;
+    mod: boolean;
+    vip: boolean;
+    artist: boolean;
+    founder: boolean;
+    subscriber: boolean;
+    follower: boolean;
+    viewer: boolean;
+    isGlobalCommand: boolean;
+    restriction: OnlineState;
+    handle(channel: string, commandName: string, userstate: ChatUser, message: string, args?: any): Promise<void>;
+}
+```
+
+### Properties
+
+| Property | Type | Description |
+|---|---|---|
+| `exp` | `RegExp` | Pattern matched against the raw chat message. The first capture group is the command name; subsequent groups become `args`. |
+| `timeout` | `number` | Cooldown period in seconds. Privileged users (mod, VIP, subscriber, etc.) receive half this duration. |
+| `mod` | `boolean` | Allow channel moderators. |
+| `vip` | `boolean` | Allow VIPs. |
+| `artist` | `boolean` | Allow users with the Artist channel role. |
+| `founder` | `boolean` | Allow Founders (earliest subscribers). Must match `subscriber` - if `subscriber: true`, set `founder: true`. |
+| `subscriber` | `boolean` | Allow current subscribers. |
+| `follower` | `boolean` | Allow followers (non-subscribers who follow). |
+| `viewer` | `boolean` | Allow anyone in chat, including non-followers. |
+| `isGlobalCommand` | `boolean` | When `true`, the cooldown is shared across all users. Per-user cooldown is not yet implemented. |
+| `restriction` | `OnlineState` | `'always'` - runs any time. `'online'` - only while stream is live. `'offline'` - only while stream is offline. |
+
+---
+
+## Permission Model (RBAC)
+
+Authorization is role-based. A command declares which roles are permitted via its boolean flags. A user is authorized if they hold **at least one** of the allowed roles.
+
+### Roles and Twurple Properties
+
+| Flag | Twurple property | Notes |
+|---|---|---|
+| `mod` | `ChatUser.isMod` | Covers Lead Mod - Twurple does not distinguish |
+| `vip` | `ChatUser.isVip` | |
+| `artist` | `ChatUser.isArtist` | Channel Artist badge |
+| `founder` | `ChatUser.isFounder` | A permanent badge from early subscription - the holder may no longer be subscribed or following |
+| `subscriber` | `ChatUser.isSubscriber` | A temporary badge the holder receives from subscribing or receiving a sub to the channel |
+| `follower` | `broadcaster.isFollowedBy(userId)` | Async API call; resolved before authorization |
+| `viewer` | _(always true)_ | Open to everyone in chat |
+
+Broadcaster (`ChatUser.isBroadcaster`) always passes regardless of flags.
+
+### Implied Relationships
+
+- **Subscriber implies follower.** Twitch requires following before subscribing. A subscriber satisfies any command that allows followers.
+- **Founder implies follower.** Same logic - founders subscribed, and subscribing requires following.
+- **Roles do not imply subscription.** A mod or VIP who is not subscribed does not satisfy `subscriber: true`.
+
+### Authorization Logic
+
+```
+broadcaster          -> always authorized
+mod flag + isMod     -> authorized
+vip flag + isVip     -> authorized
+artist flag + isArtist -> authorized
+founder flag + isFounder -> authorized
+subscriber flag + isSubscriber -> authorized
+follower flag + (isFollower OR isSubscriber) -> authorized
+viewer flag          -> authorized
+otherwise            -> denied
+```
+
+---
+
+## Cooldown Behavior
+
+The `timeout` value is the base cooldown in seconds. Privileged users (founder, mod, subscriber, VIP, artist) receive `timeout / 2`. The broadcaster has no cooldown.
+
+Global cooldowns (`isGlobalCommand: true`) are shared - once any user triggers the cooldown, the command is unavailable to everyone until the period expires.
+
+---
+
+## Adding a New Command
+
+### 1. Create the class
+
+Create a file in `bot/commands/`. Implement `ICommandHandler`:
+
+```typescript
+import { ChatClient, ChatUser } from '@twurple/chat';
+import { inject, injectable } from 'inversify';
+import { ICommandHandler, OnlineState } from './iCommandHandler';
+import InjectionTypes from '../../dependency-management/types';
+
+@injectable()
+export class MyCommand implements ICommandHandler {
+    exp: RegExp = /^!(mycommand)$/i;
+    timeout: number = 10;
+    mod: boolean = false;
+    vip: boolean = false;
+    artist: boolean = false;
+    founder: boolean = true;   // must match subscriber
+    subscriber: boolean = true;
+    follower: boolean = false;
+    viewer: boolean = false;
+    isGlobalCommand: boolean = true;
+    restriction: OnlineState = 'online';
+
+    constructor(
+        @inject(ChatClient) private chatClient: ChatClient,
+        @inject(InjectionTypes.Logger) private logger: winston.Logger,
+    ) {}
+
+    async handle(channel: string, commandName: string, userstate: ChatUser, message: string, args?: any): Promise<void> {
+        this.chatClient.say(channel, 'Hello!');
+        this.logger.info(`* Executed ${commandName} in ${channel} || ${userstate.displayName} > ${message}`);
+    }
+}
+```
+
+**Flag guidance:**
+- `viewer: true` - open to everyone (all other flags become irrelevant)
+- `follower: true` - requires following; set this for community participation commands
+- `subscriber: true` + `founder: true` - subscriber-exclusive perks
+- `vip: true` - high-trust viewer privilege
+- `mod: true` - moderation or privileged commands; exclude subscriber/follower/viewer
+- Multiple flags can be `true` simultaneously (a mod can also be a subscriber - both paths authorize them)
+
+### 2. Register in the DI container
+
+In `dependency-management/inversify.config.ts`, add a multi-binding under `InjectionTypes.CommandHandlers`:
+
+```typescript
+container.bind<ICommandHandler>(InjectionTypes.CommandHandlers).to(MyCommand);
+```
+
+`MessageHandler` discovers all bound command handlers automatically via `@multiInject`.
+
+### 3. Export from the index
+
+Add the export to `bot/commands/index.ts` so the class is importable from the module root.
+
+---
+
+## Deferred Roles
+
+The following Twitch roles are not yet represented as permission flags because they have no direct boolean property on Twurple's `ChatUser` type. Access requires badge inspection. Tracked in issue #96.
+
+| Role | Detection method |
+|---|---|
+| Editor | `chatUser.badges.has('editor')` (badge key TBC) |
+| Business Manager | `chatUser.badges.has(...)` (badge key TBC) |

--- a/docs/command-system.md
+++ b/docs/command-system.md
@@ -70,7 +70,6 @@ Broadcaster (`ChatUser.isBroadcaster`) always passes regardless of flags.
 ### Implied Relationships
 
 - **Subscriber implies follower.** Twitch requires following before subscribing. A subscriber satisfies any command that allows followers.
-- **Founder implies follower.** Same logic - founders subscribed, and subscribing requires following.
 - **Roles do not imply subscription.** A mod or VIP who is not subscribed does not satisfy `subscriber: true`.
 
 ### Authorization Logic


### PR DESCRIPTION
## Summary

- Fixes a critical authorization bug where `isAuthorized()` was declared `async` but never
  awaited at the call site — every user passed authorization unconditionally prior to this change
- Fixes the `follower` permission flag which was previously inert; the fallback `return isFollower`
  ignored the flag entirely, allowing any follower to run any command
- Adds `artist` and `founder` permission flags to `ICommandHandler`, backed by Twurple's
  `ChatUser.isArtist` and `ChatUser.isFounder` properties
- Implements proper RBAC: each command declares which roles are permitted; a user is authorized
  if they hold at least one. Subscribers satisfy follower-level checks (subscribing requires following)
- Adds `docs/command-system.md` documenting the command interface, RBAC permission model, role
  implications, and a guide for adding new commands

## Closes

Closes #39

## Test plan

- [x] Broadcaster can run any command regardless of flags
- [x] Mod can run a mod-only command without being subscribed
- [x] Subscriber can run a follower-level command (implied follower access)
- [x] Non-subscriber follower is blocked from subscriber-only commands (`follower: false`)
- [x] Non-follower viewer is blocked from follower-level commands
- [x] Founder passes `founder`-flagged commands regardless of current subscription status
