### PR TITLE
Feature/ci unit tests

### DIFF
--- a/.claude/skills/gitkraken-commit-msg/SKILL.md
+++ b/.claude/skills/gitkraken-commit-msg/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: gitkraken-commit-msg
+description: Generate a commit message to be used in GitKraken. Will have a title of 72 characters and a body if more is needed
+---
+
+<!-- Tip: Use /create-skill in chat to generate content with agent assistance -->
+
+* Git Kraken has two components to a commit message:
+   * Title:
+      * (Require)
+      * Format: `<type>[(<scope>)][!]: <description>`
+      * Soft Max Length 50
+      * Hard Max length 72
+      * `<type>`: one of `feat`, `fix`, `refactor`, `perf`, `style`, `test`,
+        `docs`, `build`, `ops`, `chore`
+      * `<scope>` (optional): project-specific noun in parens - never an
+        issue identifier
+      * Breaking change: `!` immediately before the colon
+      * `<description>`: imperative present tense, no capitalized first
+        letter, no trailing period
+   * Body:
+      * (Optional)
+      * Bullet points are '*' not '-'
+      * Explains motivation/contrast with prior behavior, imperative tense
+      * Footer-style trailers (issue refs, `BREAKING CHANGE:`,
+        co-authorship) go at the end, separated by a blank line
+* References:
+   * https://gist.github.com/qoomon/5dfcdf8eec66a051ecd85625518cfd13
+   * https://www.conventionalcommits.org/en/v1.0.0/
+* Validate that we are not on the 'main' branch
+* Read git diff --staged, git diff (unstaged), and git status (untracked
+  files) to build a full picture of all pending changes
+* Identify/callout relevancy issues across the full picture - e.g. staged
+  changes that mix unrelated concerns, or unstaged/untracked changes that
+  look related to what's staged and may have been left out by mistake
+* Draft and Present feedback about files to be staged and those unstaged
+    * Optional - do not present if there are no issues
+    * Markdown format
+    * Ability for user to copy
+* Draft and Present the commit message from what's staged
+    * Markdown format
+    * Ability for user to copy
+    * Unstaged/Untracked findings are feedback
+    * Imperative mood/tone
+    * Always append a co-authorship trailer, formatted per Claude Code's
+      standard convention

--- a/.claude/skills/gitkraken-commit-msg/SKILL.md
+++ b/.claude/skills/gitkraken-commit-msg/SKILL.md
@@ -21,7 +21,10 @@ description: Generate a commit message to be used in GitKraken. Will have a titl
    * Body:
       * (Optional)
       * Bullet points are '*' not '-'
-      * Explains motivation/contrast with prior behavior, imperative tense
+      * Terse
+         * One relevant fact per bullet
+         * Imperative tense
+         * No padding or editorializing (e.g. no noting consistency with other files)
       * Footer-style trailers (issue refs, `BREAKING CHANGE:`,
         co-authorship) go at the end, separated by a blank line
 * References:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .git/
+.claude/
 .vscode/
 node_modules/
 logs/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.claude/plans/
+.claude/tmp/
 node_modules/
 logs/
 .env

--- a/bot/commands/followAgeCommand.spec.ts
+++ b/bot/commands/followAgeCommand.spec.ts
@@ -14,6 +14,17 @@ import { FollowAgeCommand } from './followAgeCommand';
 import Timespan, { getAgeReport } from '../utilities/timeSpan';
 import environment from '../../configurations/environment';
 
+jest.mock('../../configurations/environment', () => ({
+    __esModule: true,
+    default: {
+        twitchBot: {
+            broadcaster: {
+                id: 'test-broadcaster-id',
+            },
+        },
+    },
+}));
+
 describe('Follow Age Command Tests', () => {
     const channel = 'TestChannel';
     const command = 'TestCommand';
@@ -84,7 +95,7 @@ describe('Follow Age Command Tests', () => {
             const age = getAgeReport(Timespan.fromNow(followUser.followDate));
 
             // Act
-            await subject.handle(channel, command, chatUser, message, args);
+            await subject?.handle(channel, command, chatUser, message, args);
 
             // Assert
             if (args[1]) {

--- a/bot/commands/socialsCommand.spec.ts
+++ b/bot/commands/socialsCommand.spec.ts
@@ -12,6 +12,19 @@ import { ICommandHandler } from './iCommandHandler';
 import { SocialsCommand } from './socialsCommand';
 import environment from '../../configurations/environment';
 
+jest.mock('../../configurations/environment', () => ({
+    __esModule: true,
+    default: {
+        discordInvite: 'test-discord-invite',
+        twitter: {
+            link: 'test-twitter-link',
+        },
+        youtube: {
+            link: 'test-youtube-link',
+        },
+    },
+}));
+
 describe('Socials Command Tests', () => {
     const channel = 'TestChannel';
     const command = 'TestCommand';
@@ -51,17 +64,17 @@ describe('Socials Command Tests', () => {
             .find(x => x.constructor.name === `${SocialsCommand.name}`);
 
         // Act
-        await subject.handle(channel, command, user, message, []);
+        await subject?.handle(channel, command, user, message, []);
 
         // Assert
         expect(expectedChatClient.say)
             .toHaveBeenCalledTimes(1);
         expect(expectedChatClient.say)
-            .toHaveBeenCalledWith(channel, expect.stringContaining(environment.discordInvite));
+            .toHaveBeenCalledWith(channel, expect.stringContaining(environment.discordInvite!));
         expect(expectedChatClient.say)
-            .toHaveBeenCalledWith(channel, expect.stringContaining(environment.twitter.link));
+            .toHaveBeenCalledWith(channel, expect.stringContaining(environment.twitter.link!));
         expect(expectedChatClient.say)
-            .toHaveBeenCalledWith(channel, expect.stringContaining(environment.youtube.link));
+            .toHaveBeenCalledWith(channel, expect.stringContaining(environment.youtube.link!));
 
         expect(expectedLogger.info)
             .toHaveBeenCalledWith(expect


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml`, the first CI pipeline in this repo (issue #11)
  - Triggers on push/PR to `main`, runs `npm ci` + `npm test` (Jest unit suite) on
    Node 20, no Postgres service needed since the current suite is fully mocked
  - Establishes the CI shell that lint (#104) and coverage (#106) will layer onto
- Adds `.claude/skills/gitkraken-commit-msg/` - a Claude Code skill that drafts
  GitKraken-ready commit titles/bodies following Conventional Commits, gated on
  branch (never `main`) and staged-diff relevancy checks
- Updates `.gitignore` to treat `.claude/plans/` and `.claude/tmp/` as local-only
  scratch, and `.dockerignore` to exclude all of `.claude/` from the Docker build
  context

## Test plan
- [x] Confirm the `CI / Unit Tests` check runs and passes on this PR
- [x] `npm test` passes locally
- [x] Invoke `/gitkraken-commit-msg` against a staged change and confirm it drafts
      a correctly formatted message
- [x] `git status` no longer shows `.claude/plans/` or `.claude/tmp/` contents as
      untracked

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
