### PR TITLE
Feature/108 automate docker build and push

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,14 @@
-.git/
+# Folders
 .claude/
+.git/
 .vscode/
-node_modules/
+coverage/
 logs/
 local-cache/
-coverage/
-Dockerfile
+node_modules/
+
+# Files
 .dockerignore
-Dockerfile
-compose.yaml
 .gitignore
+compose.yaml
+Dockerfile

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,53 @@
+name: Docker Build and Deploy
+
+on:
+    workflow_dispatch:
+        inputs:
+            dry_run:
+                type: boolean
+                description: "Skip the push step"
+                default: false
+
+permissions:
+    contents: read
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+env:
+    IMAGE_NAME: "itanex/stream-assist-bot"
+
+jobs:
+    build-and-deploy:
+        name: Build and Deploy
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Load release environment
+              run: |
+                  cat .env.release >> "$GITHUB_ENV"
+
+            - name: Docker - Login
+              uses: docker/login-action@v4
+              with:
+                  username: ${{ secrets.DOCKER_HUB_USERNAME }}
+                  password: ${{ secrets.DOCKER_HUB_TOKEN  }}
+                  registry: docker.io
+
+            - name: Docker - Build Container
+              run: |
+                  docker build \
+                    --target prod \
+                    -t ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} \
+                    -t ${{ env.IMAGE_NAME }}:latest \
+                    .
+
+            - name: Docker - Push Containers
+              if: ${{ !inputs.dry_run }}
+              run: |
+                  docker push ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+                  docker push ${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
## Summary
* Add a manually-triggered GHA workflow (docker-build.yml) that builds and pushes itanex/stream-assist-bot to Docker Hub
* Version tag comes from .env.release (written by the #107 release tooling); latest is pushed alongside it
* dry_run input skips the push step so the build can be validated without publishing

## Test plan
- [x] Run workflow manually via workflow_dispatch with dry_run: true, confirm build succeeds and push is skipped
- [x] Run again with dry_run: false, confirm both tags land in Docker Hub

Refs #108
