### PR TITLE
Feature/109 create release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,38 +1,38 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
+    workflow_call:
 
 permissions:
-  contents: read
+    contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 
 jobs:
-  test:
-    name: Unit Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+    test:
+        name: Unit Tests
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v7
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
+            - name: Setup Node
+              uses: actions/setup-node@v6
+              with:
+                  cache: "npm"
 
-      - name: Install dependencies
-        run: npm ci
+            - name: Install dependencies
+              run: npm ci
 
-      - name: Run Lint
-        run: npm run lint
-      
-      - name: Run unit tests
-        run: npm test
+            - name: Run Lint
+              run: npm run lint
+
+            - name: Run unit tests
+              run: npm test

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,12 +1,27 @@
 name: Docker Build and Deploy
 
 on:
+    workflow_call:
+        inputs:
+            dry_run:
+                type: boolean
+                description: "Skip the push step"
+                default: false
+            ref:
+                type: string
+                description: "Git ref (tag, branch, SHA) to build. Defaults to the triggering ref."
+                default: ""
+
     workflow_dispatch:
         inputs:
             dry_run:
                 type: boolean
                 description: "Skip the push step"
                 default: false
+            ref:
+                type: string
+                description: "Git ref (tag, branch, SHA) to build. Defaults to the triggering ref."
+                default: ""
 
 permissions:
     contents: read
@@ -25,7 +40,10 @@ jobs:
         timeout-minutes: 10
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
+              with:
+                  # Empty ref falls back to default checkout behavior
+                  ref: ${{ inputs.ref }}
 
             - name: Load release environment
               run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Full Release
+
+on:
+    workflow_dispatch:
+        inputs:
+            version_bump:
+                required: true
+                type: choice
+                description: "Which version fragment to bump."
+                default: "patch"
+                options:
+                    - patch
+                    - minor
+                    - major
+            no_increment:
+                type: boolean
+                description: "Rerun current version. No version increment."
+                default: false
+            github_release:
+                type: boolean
+                description: "Create a GitHub Release for the new tag."
+                default: true
+
+permissions:
+    contents: read
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    ci:
+        name: CI Gate
+        uses: ./.github/workflows/ci.yml
+
+    tag_version:
+        name: Tag Version
+        needs: ci
+        uses: ./.github/workflows/tag-version.yml
+        permissions:
+            contents: write
+        with:
+            version_bump: ${{ inputs.version_bump }}
+            no_increment: ${{ inputs.no_increment }}
+
+    docker:
+        name: Docker Build and Deploy
+        needs: [ci, tag_version]
+        uses: ./.github/workflows/docker-build.yml
+        secrets: inherit
+        with:
+            ref: ${{ needs.tag_version.outputs.tag }}
+
+    github_release:
+        name: GitHub Release
+        needs: [tag_version, docker]
+        if: ${{ inputs.github_release }}
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        permissions:
+            contents: write
+        steps:
+            - name: Create GitHub Release
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  TAG: ${{ needs.tag_version.outputs.tag }}
+              run: |
+                  gh release create "$TAG" \
+                    --repo "$GITHUB_REPOSITORY" \
+                    --title "$TAG" \
+                    --verify-tag \
+                    --generate-notes

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -1,0 +1,79 @@
+name: Tag Version
+
+on:
+    workflow_call:
+        inputs:
+            version_bump:
+                required: true
+                type: string
+                description: "Which version fragment to bump."
+            no_increment:
+                type: boolean
+                description: "Rerun current version. No version increment."
+                default: false
+    workflow_dispatch:
+        inputs:
+            version_bump:
+                required: true
+                type: choice
+                description: "Which version fragment to bump."
+                default: "patch"
+                options:
+                    - patch
+                    - minor
+                    - major
+            no_increment:
+                type: boolean
+                description: "Rerun current version. No version increment."
+                default: false
+            dry_run:
+                type: boolean
+                description: "Do not modify, just validate."
+                default: false
+
+permissions:
+    contents: read
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    tag_version:
+        name: Tag Version
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "20"
+                  cache: "npm"
+
+            - name: Install dependencies
+              run: npm ci
+
+            # ----------------------------------------------------
+            # Runs release-it
+            # * (Required) Configures version_bump (workflow input)
+            # * (Optional) Inlcudes no-increment option (workflow input)
+            # * (Optional) Includes dry-run option (workflow input)
+            # NOTE:
+            # > Updates .env.release
+            # > Updates package.json
+            # > Creates Tag for target branch
+            # ----------------------------------------------------
+            - name: Update Version
+              run: |
+                  CMD="npm run release -- --ci --increment=${{github.event.inputs.version_bump}}"
+                  if [ "${{ github.event.inputs.no_increment }}" = "true" ]; then
+                      CMD="$CMD --no-increment"
+                  fi
+                  if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+                      CMD="$CMD --dry-run"
+                  fi
+                  echo "Running: $CMD"
+                  $CMD

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -11,6 +11,10 @@ on:
                 type: boolean
                 description: "Rerun current version. No version increment."
                 default: false
+        outputs:
+            tag:
+                description: "The git tag created for this version."
+                value: ${{ jobs.tag_version.outputs.tag }}
     workflow_dispatch:
         inputs:
             version_bump:
@@ -32,7 +36,7 @@ on:
                 default: false
 
 permissions:
-    contents: read
+    contents: write
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
@@ -43,18 +47,28 @@ jobs:
         name: Tag Version
         runs-on: ubuntu-latest
         timeout-minutes: 10
+        outputs:
+            tag: ${{ steps.version.outputs.tag }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
+              with:
+                  fetch-depth: 0
 
             - name: Setup Node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
-                  node-version: "20"
                   cache: "npm"
 
             - name: Install dependencies
               run: npm ci
+
+            # Identity must be set before release-it runs,
+            # as release-it creates the version commit and tag
+            - name: Setup git config
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "430586+itanex@users.noreply.github.com"
 
             # ----------------------------------------------------
             # Runs release-it
@@ -65,15 +79,22 @@ jobs:
             # > Updates .env.release
             # > Updates package.json
             # > Creates Tag for target branch
+            # > Pushes commit and tag to origin
             # ----------------------------------------------------
             - name: Update Version
               run: |
-                  CMD="npm run release -- --ci --increment=${{github.event.inputs.version_bump}}"
-                  if [ "${{ github.event.inputs.no_increment }}" = "true" ]; then
+                  CMD="npm run release -- --ci --increment=${{ inputs.version_bump }}"
+                  if [ "${{ inputs.no_increment }}" = "true" ]; then
                       CMD="$CMD --no-increment"
                   fi
-                  if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+                  if [ "${{ inputs.dry_run }}" = "true" ]; then
                       CMD="$CMD --dry-run"
                   fi
                   echo "Running: $CMD"
                   $CMD
+
+            # release-it owns commit, tag, and push (git.push: true)
+            # This step only surfaces the new tag for workflow_call consumers
+            - name: Capture version tag
+              id: version
+              run: echo "tag=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"

--- a/.release-it.json
+++ b/.release-it.json
@@ -2,7 +2,7 @@
   "git": {
     "commitMessage": "chore(version): bump to ${version}",
     "tagName": "${version}",
-    "push": false
+    "push": true
   },
   "npm": {
     "publish": false

--- a/readme.md
+++ b/readme.md
@@ -6,11 +6,11 @@ NodeJS application that interprets commands and events on Twitch for the dedicat
 
 ## Built With
 
-- Typescript
-- NodeJS/Ts-Node
-- PostgreSQL
-- Sequelize/Typescript-Sequelize
-- Docker
+* Typescript
+* NodeJS/Ts-Node
+* PostgreSQL
+* Sequelize/Typescript-Sequelize
+* Docker
 
 ## Getting Started
 
@@ -32,7 +32,7 @@ To pre-seed a token instead, create `auth-tokens.{TWITCH_BROADCASTER_ID}.json` i
 
 ### Deployment
 
-> Note: Deployment is currently manual and local. CI/CD via a hosted service is not yet configured.
+> Note: Local deployment is manual via Docker Compose. Image publishing and releases are automated - see [CI & Release Workflows](#ci--release-workflows).
 
 **First run or after code changes - rebuild the image and start:**
 
@@ -60,6 +60,101 @@ docker compose logs -f app
 
 The `-d` flag detaches immediately after starting. Omit it to follow logs in the foreground, but prefer `docker compose logs -f app` for monitoring a running deployment.
 
+## CI & Release Workflows
+
+All automation lives in `.github/workflows/`. Three workflows are reusable building blocks (each supports `workflow_call`), and **Full Release** orchestrates them end to end.
+
+### CI (`ci.yml`)
+
+The quality gate: installs dependencies, runs lint, runs unit tests.
+
+**Triggers**:
+* push to `main`
+* pull requests targeting `main`
+* `workflow_call` (used as the gate in Full Release)
+
+**Inputs / secrets**: none.
+
+**Guidelines**: this is the only merge gate - if it passes, the branch is releasable.
+
+### Tag Version (`tag-version.yml`)
+
+Runs [release-it](https://github.com/release-it/release-it) (configured in `.release-it.json`) to perform the version bump. release-it owns the full git lifecycle: it updates `package.json` and `.env.release`, commits, tags, and pushes.
+
+**Triggers**:
+* `workflow_dispatch` (standalone bump)
+* `workflow_call` (from Full Release)
+
+**Inputs:**
+| Input | Type | Notes |
+|---|---|---|
+| `version_bump` | choice: `patch` / `minor` / `major` | Required. Which version fragment to bump. |
+| `no_increment` | boolean | Rerun the current version without bumping. |
+| `dry_run` | boolean | Dispatch only. Prints what would happen; no commit, tag, or push. |
+
+**Outputs**: `tag` - the version that was tagged (bare version, no `v` prefix), consumed by callers.
+
+**Guidelines**:
+* Use `dry_run` to validate release-it behavior after changing `.release-it.json` - dry-run always wins over config, so no git action executes.
+* An **un-released bump** (run this standalone, release later via Full Release with `no_increment`) is a supported pattern.
+
+### Docker Build and Deploy (`docker-build.yml`)
+
+Builds the production image and pushes it to Docker Hub as `itanex/stream-assist-bot:<version>` and `:latest`. The version tag comes from `IMAGE_TAG` in `.env.release` *at the built ref*.
+
+**Triggers**:
+* `workflow_dispatch` (standalone build)
+* `workflow_call` (from Full Release)
+
+**Inputs:**
+| Input | Type | Notes |
+|---|---|---|
+| `dry_run` | boolean | Build but skip the push. |
+| `ref` | string | Git ref (tag, branch, SHA) to build. Empty = the triggering ref. Full Release passes the freshly created tag here. |
+
+**Secrets**:
+* `DOCKER_HUB_USERNAME`,
+* `DOCKER_HUB_TOKEN`
+
+**Guidelines**: To rebuild a published version against a patched base docker image without touching the repo, dispatch this workflow directly with `ref` set to that version tag.
+
+### Full Release (`release.yml`)
+
+The single-invocation release pipeline. Manual `workflow_dispatch` only.
+
+**Inputs:**
+| Input | Type | Notes |
+|---|---|---|
+| `version_bump` | choice: `patch` / `minor` / `major` | Required. Passed to Tag Version. |
+| `no_increment` | boolean | Re-release the current version (see below). |
+| `github_release` | boolean, default `true` | Create a GitHub Release for the tag after the image ships. |
+
+```mermaid
+flowchart TD
+    A[workflow_dispatch: Full Release] --> B[CI Gate<br/>lint + unit tests]
+    B -- fail --> X[Run stops - nothing tagged or shipped]
+    B -- pass --> C[Tag Version<br/>release-it: bump, commit, tag, push]
+    C --> D[Docker Build and Deploy<br/>builds the new tag, pushes version + latest]
+    D --> E{github_release?}
+    E -- true --> F[Create GitHub Release<br/>gh release create, auto-generated notes]
+    E -- false --> G[Done]
+    F --> G
+```
+
+**Guidelines**:
+* Each stage gates the next via `needs:` - a lint/test failure stops the run before anything is tagged.
+* The Docker stage builds the tag created in the same run (not the SHA the run started from), so the image always matches the tagged commit.
+* A tag can have at most **one** GitHub Release; `github_release` fails if one already exists for the version.
+
+#### Re-releasing a version (`no_increment`)
+
+To rebuild and re-push an existing version (e.g. a base-image CVE fix with no repo changes): set `no_increment: true` and **uncheck `github_release`** (the release for that tag already exists).
+
+Two boundaries to respect:
+
+* The tag does not move. The rebuild uses the tag's original commit, so it only picks up changes *outside* the repo (like a patched base docker image). If the fix touched any file in the repo, bump at least `patch` instead.
+* If only the docker image needs rebuilding, dispatching **Docker Build and Deploy** directly with `ref` set to the version tag is the preferred approach.
+
 ## Usage
 
 This application is distributed under the GPLv3 license and is expected to be executed under the same principles.
@@ -84,10 +179,10 @@ Distributed currently under GPLv3. For more infomation see the `License` file in
 
 ## Links
 
-- [Project Link](https://github.com/users/itanex/projects/2/)
-- [TwurpleJS](https://twurple.js.org/)
-- [Sequelize](https://sequelize.org/)
-- [Docker](https://www.docker.com/)
+* [Project Link](https://github.com/users/itanex/projects/2/)
+* [TwurpleJS](https://twurple.js.org/)
+* [Sequelize](https://sequelize.org/)
+* [Docker](https://www.docker.com/)
 
 ## Developed Live On Twitch Stream
 


### PR DESCRIPTION
## Summary

Stitches the existing CI, version-bump, and Docker publish pieces into a single
manually dispatched release pipeline, closing the gap where a manual step still
connected #107 and #108.

Closes #109

## What Changed

* **release.yml (new)** - Full Release orchestrator: CI gate -> Tag Version ->
  Docker Build and Deploy -> optional GitHub Release, chained with `needs:` so a
  failure at any stage stops the run before anything ships
* **ci.yml** - adds `workflow_call` so the release pipeline reuses the exact
  same lint/test gate as PRs
* **tag-version.yml** - git identity configured before release-it runs, leftover
  template commit step removed, new tag exposed as a `workflow_call` output
* **docker-build.yml** - adds `workflow_call` and a `ref` input so the release
  builds the freshly created tag instead of the SHA the run started from
* **.release-it.json** - `git.push` enabled; release-it now owns commit, tag,
  and push (all still skipped under `--dry-run`)
* **readme.md** - guidelines for all four workflows, including a re-release
  (`no_increment`) section and a Full Release flowchart
* **actions bumped** - checkout v4 -> v7, setup-node v4 -> v6 (clears the
  Node 20 runtime deprecation alert); explicit Node 20 pin dropped in favor of
  the runner default

## Design Decisions

* Modular workflows with an orchestrator (not one monolithic file): each stage
  stays independently dispatchable for un-released bumps and image-only rebuilds
* Orchestrator *calls* the pieces rather than chaining trigger events, avoiding
  the `GITHUB_TOKEN` no-retrigger rule entirely
* GitHub Release creation is a flag-gated final job (`github_release`, default
  true) that runs only after the image ships; one release per tag, so re-release
  runs should uncheck it

## First-Run Verification

* [x] release-it push requires an upstream; expected fine with checkout defaults
* [x] The `no_increment` + existing-tag path is untested; dry-run before relying on it
* [ ] Full Release appears in the Actions UI only after this merges to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
