### PR TITLE
ops(ci): report test coverage in job summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,13 @@ jobs:
             - name: Run Lint
               run: npm run lint
 
-            - name: Run unit tests
-              run: npm test
+            - name: Run unit tests with coverage
+              shell: bash
+              run: |
+                  npm run test-coverage | tee coverage-output.txt
+                  {
+                      echo '## Test Coverage'
+                      echo '```text'
+                      cat coverage-output.txt
+                      echo '```'
+                  } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Surfaces test coverage in CI for reference. Reporting only - no threshold
gating, per the discussion on #106.

## Changes

* Replace the `npm test` CI step with `npm run test-coverage` so the suite
  runs once with coverage collection enabled
* Append the jest coverage table to `$GITHUB_STEP_SUMMARY` so it renders on
  each run's summary page
* Set `shell: bash` explicitly so `pipefail` preserves jest's exit code
  through the `tee` capture

## Notes

* Coverage is informational only. Enforcement via thresholds was considered
  and rejected - quality tests are the goal, coverage follows organically
* No badge or external coverage service - GitHub renders the summary natively

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)
