### PR TITLE
Feature/7 db backed command phrases

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -11,6 +11,7 @@ import AuthenticationServer, { IAuthenticationServer } from './bot/auth/auth.ser
 import { isUserAuthenticated } from './bot/auth/authProvider';
 import environment from './configurations/environment';
 import { name, version } from './package.json';
+import PhraseService from './bot/utilities/phrase.service';
 
 @injectable()
 class App {
@@ -21,6 +22,7 @@ class App {
         @inject(SocketServer) private socketServer: ISocketServer,
         @inject(OverlayServer) private overlayServer: IOverlayServer,
         @inject(AuthenticationServer) private authServer: IAuthenticationServer,
+        @inject(PhraseService) private phraseService: PhraseService,
         @inject(InjectionTypes.Logger) public logger: winston.Logger,
     ) {
         this.logger.info(`** Application initialized **`);
@@ -32,13 +34,14 @@ class App {
         this.chatBot.configure();
 
         await Promise.all([
-            this.database.connect(),
-            this.database.sync(),
+            this.database.initialize(),
             this.socketServer.startServer(),
             this.overlayServer.configure(),
             this.authServer.configure(),
             this.scheduler.scheduleChatEvents(),
         ]);
+
+        await this.phraseService.initialize();
 
         this.authServer.listen();
         this.overlayServer.listen();
@@ -76,7 +79,8 @@ const application = SAContainer.get<App>(App);
 
 application.main()
     .catch(reason => {
-        application.logger.error(`Process Terminated (-1): ${reason}`);
+        const detail = reason instanceof Error ? reason.stack : String(reason);
+        application.logger.error(`Process Terminated (-1): ${detail}`);
         process.exit(1);
     });
 

--- a/bot/commands/DivideByZeroCommand.spec.ts
+++ b/bot/commands/DivideByZeroCommand.spec.ts
@@ -1,64 +1,54 @@
-// reflect-metadata should be imported
-// before any interface or other imports
-// also it should be imported only once
-// so that a singleton is created.
 import 'reflect-metadata';
-import { ChatClient, ChatUser } from '@twurple/chat';
-import { Container } from 'inversify';
-import winston from 'winston';
-import { mockChatClient, mockLogger } from '../../tests/common.mocks';
-import InjectionTypes from '../../dependency-management/types';
-import { ICommandHandler } from './iCommandHandler';
+import { ChatUser } from '@twurple/chat';
+import { mockChatClient, mockLogger, mockPhraseService } from '../../tests/common.mocks';
 import { DivideByZeroCommand } from './DivideByZeroCommand';
+import { defaultPhrases } from '../utilities/default-phrases';
 
 describe(' Divide By Zero Command Tests', () => {
     const channel = 'TestChannel';
     const command = 'TestCommand';
-    const message = 'TestMessage';
     const user = <ChatUser>{ displayName: 'TestUser' };
+    const message = 'TestMessage';
 
-    const container: Container = new Container();
-    let expectedChatClient: ChatClient;
-    let expectedLogger: winston.Logger;
+    const configuredPhrase = 'Absolute Zero';
+
+    let subject: DivideByZeroCommand;
 
     beforeEach(() => {
         jest.resetAllMocks();
-        container.unbindAll();
-        container
-            .bind<ChatClient>(ChatClient)
-            .toConstantValue(mockChatClient);
-
-        container
-            .bind<winston.Logger>(InjectionTypes.Logger)
-            .toConstantValue(mockLogger);
-
-        container
-            .bind<ICommandHandler>(InjectionTypes.CommandHandlers)
-            .to(DivideByZeroCommand);
-
-        expectedChatClient = container
-            .get(ChatClient);
-
-        expectedLogger = container
-            .get<winston.Logger>(InjectionTypes.Logger);
+        subject = new DivideByZeroCommand(
+            mockChatClient,
+            mockPhraseService,
+            mockLogger,
+        );
     });
 
-    it('should say something in chat', async () => {
+    it('says the configured phrase in chat', async () => {
         // Arrange
-        const subject = container
-            .getAll<ICommandHandler>(InjectionTypes.CommandHandlers)
-            .find(x => x.constructor.name === `${DivideByZeroCommand.name}`);
+        mockPhraseService
+            .getCommandTemplate
+            .mockReturnValue(configuredPhrase);
 
         // Act
         subject.handle(channel, command, user, message, []);
 
         // Assert
-        expect(expectedChatClient.say)
-            .toHaveBeenCalledTimes(1);
-        expect(expectedChatClient.say)
-            .toHaveBeenCalledWith(channel, expect.anything());
-        expect(expectedLogger.info)
-            .toHaveBeenCalledWith(expect
-                .stringMatching(`(?=.*\\b${command}\\b)(?=.*\\b${channel}\\b)(?=.*\\b${user.displayName}\\b)(?=.*\\b${message}\\b)`));
+        expect(mockChatClient.say).toHaveBeenNthCalledWith(1, channel, configuredPhrase);
+        expect(mockLogger.info).toHaveBeenCalledWith(expect.anything());
+    });
+
+    it('says the default phrase and logs a warning when no phrase is configured', async () => {
+        // Arrange
+        mockPhraseService
+            .getCommandTemplate
+            .mockReturnValue(undefined);
+
+        // Act
+        await subject.handle(channel, command, user, message);
+
+        // Assert
+        expect(mockChatClient.say).toHaveBeenNthCalledWith(1, channel, defaultPhrases.dividebyzero);
+        expect(mockLogger.warn).toHaveBeenCalledWith(expect.anything());
+        expect(mockLogger.info).toHaveBeenCalledWith(expect.anything());
     });
 });

--- a/bot/commands/DivideByZeroCommand.ts
+++ b/bot/commands/DivideByZeroCommand.ts
@@ -3,10 +3,13 @@ import { inject, injectable } from 'inversify';
 import winston from 'winston';
 import InjectionTypes from '../../dependency-management/types';
 import { ICommandHandler, OnlineState } from './iCommandHandler';
+import { defaultPhrases, PhraseKey } from '../utilities/default-phrases';
+import PhraseService from '../utilities/phrase.service';
 
 @injectable()
 export class DivideByZeroCommand implements ICommandHandler {
     exp: RegExp = /^!(DivideByZero)$/i;
+    phraseKey: PhraseKey = 'dividebyzero';
     timeout: number = 20;
     mod: boolean = true;
     vip: boolean = true;
@@ -20,13 +23,19 @@ export class DivideByZeroCommand implements ICommandHandler {
 
     constructor(
         @inject(ChatClient) private chatClient: ChatClient,
+        @inject(PhraseService) private phraseService: PhraseService,
         @inject(InjectionTypes.Logger) private logger: winston.Logger,
     ) {
     }
 
     async handle(channel: string, commandName: string, userstate: ChatUser, message: string, args?: any): Promise<void> {
-        this.chatClient.say(channel, `Sorry I am too smart for your silly games!`);
+        const commandTemplate = this.phraseService.getCommandTemplate(this.phraseKey);
 
+        if (!commandTemplate) {
+            this.logger.warn(`* Command Phrase not found for ${commandName} in ${channel} || ${userstate.displayName} > ${message}`);
+        }
+
+        this.chatClient.say(channel, commandTemplate ?? defaultPhrases.dividebyzero);
         this.logger.info(`* Executed ${commandName} in ${channel} :: ${userstate.displayName} > ${message}`);
     }
 }

--- a/bot/commands/aboutCommand.spec.ts
+++ b/bot/commands/aboutCommand.spec.ts
@@ -1,15 +1,9 @@
-// reflect-metadata should be imported
-// before any interface or other imports
-// also it should be imported only once
-// so that a singleton is created.
 import 'reflect-metadata';
-import { ChatClient, ChatUser } from '@twurple/chat';
-import { Container } from 'inversify';
-import winston from 'winston';
+import { ChatUser } from '@twurple/chat';
 import { mockChatClient, mockLogger } from '../../tests/common.mocks';
-import InjectionTypes from '../../dependency-management/types';
-import { ICommandHandler } from './iCommandHandler';
 import { AboutCommand } from './aboutCommand';
+import PhraseService from '../utilities/phrase.service';
+import { defaultPhrases } from '../utilities/default-phrases';
 
 describe('About Command Tests', () => {
     const channel = 'TestChannel';
@@ -17,45 +11,46 @@ describe('About Command Tests', () => {
     const user = <ChatUser>{ displayName: 'TestUser' };
     const message = 'TestMessage';
 
-    const container: Container = new Container();
-    let expectedChatClient: ChatClient;
-    let expectedLogger: winston.Logger;
+    const configuredPhrase = 'About Me';
+    const mockGetCommand = jest.fn();
+    const mockPhraseService = <unknown>{
+        getCommandTemplate: mockGetCommand,
+    } as PhraseService;
+
+    let subject: AboutCommand;
 
     beforeEach(() => {
         jest.resetAllMocks();
-        container.unbindAll();
-        container
-            .bind<ChatClient>(ChatClient)
-            .toConstantValue(mockChatClient);
 
-        container
-            .bind<winston.Logger>(InjectionTypes.Logger)
-            .toConstantValue(mockLogger);
-
-        container
-            .bind<ICommandHandler>(InjectionTypes.CommandHandlers)
-            .to(AboutCommand);
-
-        expectedChatClient = container
-            .get(ChatClient);
-
-        expectedLogger = container
-            .get<winston.Logger>(InjectionTypes.Logger);
+        subject = new AboutCommand(
+            mockChatClient,
+            mockPhraseService,
+            mockLogger,
+        );
     });
 
-    it('should say something in chat about bot', () => {
-        // arrange
-        const subject = container
-            .getAll<ICommandHandler>(InjectionTypes.CommandHandlers)
-            .find(x => x.constructor.name === `${AboutCommand.name}`);
+    it('should say something in chat about bot', async () => {
+        // Arrange
+        mockGetCommand.mockReturnValue(configuredPhrase);
 
-        // act
-        subject.handle(channel, command, user, message);
+        // Act
+        await subject.handle(channel, command, user, message);
 
-        // assert
-        expect(expectedChatClient.say).toHaveBeenCalledWith(channel, expect.anything());
-        expect(expectedLogger.info)
-            .toHaveBeenCalledWith(expect
-                .stringMatching(`(?=.*\\b${command}\\b)(?=.*\\b${channel}\\b)(?=.*\\b${user.displayName}\\b)(?=.*\\b${message}\\b)`));
+        // Assert
+        expect(mockChatClient.say).toHaveBeenCalledWith(channel, configuredPhrase);
+        expect(mockLogger.info).toHaveBeenCalledWith(expect.anything());
+    });
+
+    it('should create a warn log when the command is not-found (undefined)', async () => {
+        // Arrange
+        mockGetCommand.mockReturnValue(undefined);
+
+        // Act
+        await subject.handle(channel, command, user, message);
+
+        // Assert
+        expect(mockChatClient.say).toHaveBeenCalledWith(channel, defaultPhrases.about);
+        expect(mockLogger.warn).toHaveBeenCalledWith(expect.anything());
+        expect(mockLogger.info).toHaveBeenCalledWith(expect.anything());
     });
 });

--- a/bot/commands/aboutCommand.spec.ts
+++ b/bot/commands/aboutCommand.spec.ts
@@ -1,8 +1,7 @@
 import 'reflect-metadata';
 import { ChatUser } from '@twurple/chat';
-import { mockChatClient, mockLogger } from '../../tests/common.mocks';
+import { mockChatClient, mockLogger, mockPhraseService } from '../../tests/common.mocks';
 import { AboutCommand } from './aboutCommand';
-import PhraseService from '../utilities/phrase.service';
 import { defaultPhrases } from '../utilities/default-phrases';
 
 describe('About Command Tests', () => {
@@ -12,10 +11,6 @@ describe('About Command Tests', () => {
     const message = 'TestMessage';
 
     const configuredPhrase = 'About Me';
-    const mockGetCommand = jest.fn();
-    const mockPhraseService = <unknown>{
-        getCommandTemplate: mockGetCommand,
-    } as PhraseService;
 
     let subject: AboutCommand;
 
@@ -29,27 +24,31 @@ describe('About Command Tests', () => {
         );
     });
 
-    it('should say something in chat about bot', async () => {
+    it('says the configured phrase in chat', async () => {
         // Arrange
-        mockGetCommand.mockReturnValue(configuredPhrase);
+        mockPhraseService
+            .getCommandTemplate
+            .mockReturnValue(configuredPhrase);
 
         // Act
         await subject.handle(channel, command, user, message);
 
         // Assert
-        expect(mockChatClient.say).toHaveBeenCalledWith(channel, configuredPhrase);
+        expect(mockChatClient.say).toHaveBeenNthCalledWith(1, channel, configuredPhrase);
         expect(mockLogger.info).toHaveBeenCalledWith(expect.anything());
     });
 
-    it('should create a warn log when the command is not-found (undefined)', async () => {
+    it('says the default phrase and logs a warning when no phrase is configured', async () => {
         // Arrange
-        mockGetCommand.mockReturnValue(undefined);
+        mockPhraseService
+            .getCommandTemplate
+            .mockReturnValue(undefined);
 
         // Act
         await subject.handle(channel, command, user, message);
 
         // Assert
-        expect(mockChatClient.say).toHaveBeenCalledWith(channel, defaultPhrases.about);
+        expect(mockChatClient.say).toHaveBeenNthCalledWith(1, channel, defaultPhrases.about);
         expect(mockLogger.warn).toHaveBeenCalledWith(expect.anything());
         expect(mockLogger.info).toHaveBeenCalledWith(expect.anything());
     });

--- a/bot/commands/aboutCommand.ts
+++ b/bot/commands/aboutCommand.ts
@@ -3,10 +3,13 @@ import { inject, injectable } from 'inversify';
 import winston from 'winston';
 import InjectionTypes from '../../dependency-management/types';
 import { ICommandHandler, OnlineState } from './iCommandHandler';
+import PhraseService from '../utilities/phrase.service';
+import { defaultPhrases, PhraseKey } from '../utilities/default-phrases';
 
 @injectable()
 export class AboutCommand implements ICommandHandler {
     exp: RegExp = /!(about)/i;
+    phraseKey: PhraseKey = 'about';
     timeout: number = 5;
     mod: boolean = true;
     vip: boolean = true;
@@ -20,13 +23,19 @@ export class AboutCommand implements ICommandHandler {
 
     constructor(
         @inject(ChatClient) private chatClient: ChatClient,
+        @inject(PhraseService) private phraseService: PhraseService,
         @inject(InjectionTypes.Logger) private logger: winston.Logger,
     ) {
     }
 
     async handle(channel: string, commandName: string, userstate: ChatUser, message: string, args?: any): Promise<void> {
-        this.chatClient.say(channel, 'Today I am currently running as a TypeScript entity. My predicessor was only a little JavaScript scriptlet.');
+        const command = this.phraseService.getCommandTemplate(this.phraseKey);
 
+        if (!command) {
+            this.logger.warn(`* Command Phrase not found for ${commandName} in ${channel} || ${userstate.displayName} > ${message}`);
+        }
+
+        this.chatClient.say(channel, command ?? defaultPhrases.about);
         this.logger.info(`* Executed ${commandName} in ${channel} || ${userstate.displayName} > ${message}`);
     }
 }

--- a/bot/commands/aboutCommand.ts
+++ b/bot/commands/aboutCommand.ts
@@ -29,13 +29,13 @@ export class AboutCommand implements ICommandHandler {
     }
 
     async handle(channel: string, commandName: string, userstate: ChatUser, message: string, args?: any): Promise<void> {
-        const command = this.phraseService.getCommandTemplate(this.phraseKey);
+        const commandTemplate = this.phraseService.getCommandTemplate(this.phraseKey);
 
-        if (!command) {
+        if (!commandTemplate) {
             this.logger.warn(`* Command Phrase not found for ${commandName} in ${channel} || ${userstate.displayName} > ${message}`);
         }
 
-        this.chatClient.say(channel, command ?? defaultPhrases.about);
+        this.chatClient.say(channel, commandTemplate ?? defaultPhrases.about);
         this.logger.info(`* Executed ${commandName} in ${channel} || ${userstate.displayName} > ${message}`);
     }
 }

--- a/bot/commands/drinkCommand.spec.ts
+++ b/bot/commands/drinkCommand.spec.ts
@@ -1,65 +1,55 @@
-// reflect-metadata should be imported
-// before any interface or other imports
-// also it should be imported only once
-// so that a singleton is created.
 import 'reflect-metadata';
-import { ChatClient, ChatUser } from '@twurple/chat';
-import { Container } from 'inversify';
-import winston from 'winston';
-import { mockChatClient, mockLogger } from '../../tests/common.mocks';
-import InjectionTypes from '../../dependency-management/types';
-import { ICommandHandler } from './iCommandHandler';
+import { ChatUser } from '@twurple/chat';
+import { mockChatClient, mockLogger, mockPhraseService } from '../../tests/common.mocks';
 import { DrinkCommand } from './drinkCommand';
+import { defaultPhrases } from '../utilities/default-phrases';
 
 describe('Drink Command Tests', () => {
     const channel = 'TestChannel';
     const command = 'TestCommand';
-    const message = 'TestMessage';
     const user = <ChatUser>{ displayName: 'TestUser' };
+    const message = 'TestMessage';
 
-    const container: Container = new Container();
-    let expectedChatClient: ChatClient;
-    let expectedLogger: winston.Logger;
+    const configuredPhrase = 'Drink me!';
+
+    let subject: DrinkCommand;
 
     beforeEach(() => {
         jest.resetAllMocks();
-        container.unbindAll();
-        container
-            .bind<ChatClient>(ChatClient)
-            .toConstantValue(mockChatClient);
 
-        container
-            .bind<winston.Logger>(InjectionTypes.Logger)
-            .toConstantValue(mockLogger);
-
-        container
-            .bind<ICommandHandler>(InjectionTypes.CommandHandlers)
-            .to(DrinkCommand);
-
-        expectedChatClient = container
-            .get(ChatClient);
-
-        expectedLogger = container
-            .get<winston.Logger>(InjectionTypes.Logger);
+        subject = new DrinkCommand(
+            mockChatClient,
+            mockPhraseService,
+            mockLogger,
+        );
     });
 
-    it('should say something in chat', async () => {
+    it('says the configured phrase in chat', async () => {
         // Arrange
-        const subject = container
-            .getAll<ICommandHandler>(InjectionTypes.CommandHandlers)
-            .find(x => x.constructor.name === `${DrinkCommand.name}`);
+        mockPhraseService
+            .getCommandTemplate
+            .mockReturnValue(configuredPhrase);
 
         // Act
         await subject.handle(channel, command, user, message, []);
 
         // Assert
-        expect(expectedChatClient.say)
-            .toHaveBeenCalledTimes(1);
-        expect(expectedChatClient.say)
-            .toHaveBeenCalledWith(channel, expect.anything());
+        expect(mockChatClient.say).toHaveBeenNthCalledWith(1, channel, expect.anything());
+        expect(mockLogger.info).toHaveBeenCalledWith(expect.anything());
+    });
 
-        expect(expectedLogger.info)
-            .toHaveBeenCalledWith(expect
-                .stringMatching(`(?=.*\\b${command}\\b)(?=.*\\b${channel}\\b)(?=.*\\b${user.displayName}\\b)(?=.*\\b${message}\\b)`));
+    it('says the default phrase and logs a warning when no phrase is configured', async () => {
+        // Arrange
+        mockPhraseService
+            .getCommandTemplate
+            .mockReturnValue(undefined);
+
+        // Act
+        await subject.handle(channel, command, user, message);
+
+        // Assert
+        expect(mockChatClient.say).toHaveBeenNthCalledWith(1, channel, defaultPhrases.drink);
+        expect(mockLogger.warn).toHaveBeenCalledWith(expect.anything());
+        expect(mockLogger.info).toHaveBeenCalledWith(expect.anything());
     });
 });

--- a/bot/commands/drinkCommand.ts
+++ b/bot/commands/drinkCommand.ts
@@ -3,10 +3,13 @@ import { inject, injectable } from 'inversify';
 import winston from 'winston';
 import InjectionTypes from '../../dependency-management/types';
 import { ICommandHandler, OnlineState } from './iCommandHandler';
+import { defaultPhrases, PhraseKey } from '../utilities/default-phrases';
+import PhraseService from '../utilities/phrase.service';
 
 @injectable()
 export class DrinkCommand implements ICommandHandler {
     exp: RegExp = /^!(drink|drinkorperish)$/i;
+    phraseKey: PhraseKey = 'drink';
     timeout: number = 5;
     mod: boolean = true;
     vip: boolean = true;
@@ -20,13 +23,19 @@ export class DrinkCommand implements ICommandHandler {
 
     constructor(
         @inject(ChatClient) private chatClient: ChatClient,
+        @inject(PhraseService) private phraseService: PhraseService,
         @inject(InjectionTypes.Logger) private logger: winston.Logger,
     ) {
     }
 
     async handle(channel: string, commandName: string, userstate: ChatUser, message: string, args?: any): Promise<void> {
-        this.chatClient.say(channel, `Cheering 500 bits and Timy will do a shot. Max 8 per stream.`);
+        const commandTemplate = this.phraseService.getCommandTemplate(this.phraseKey);
 
+        if (!commandTemplate) {
+            this.logger.warn(`* Command Phrase not found for ${commandName} in ${channel} || ${userstate.displayName} > ${message}`);
+        }
+
+        this.chatClient.say(channel, commandTemplate ?? defaultPhrases.drink);
         this.logger.info(`* Executed ${commandName} in ${channel} || ${userstate.displayName} > ${message}`);
     }
 }

--- a/bot/commands/iCommandHandler.ts
+++ b/bot/commands/iCommandHandler.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-extra-semi */
 /* eslint-disable semi */
 import { ChatUser } from '@twurple/chat';
+import { PhraseKey } from '../utilities/default-phrases';
 
 /** Represents the restriction state */
 export type OnlineState = 'always' | 'online' | 'offline';
@@ -8,6 +9,8 @@ export type OnlineState = 'always' | 'online' | 'offline';
 export interface ICommandHandler {
     /** Regular Expression to identify command */
     exp: RegExp;
+    /** Used to identify command in database */
+    phraseKey?: PhraseKey;
     /** The timeout in seconds for this command */
     timeout: number;
     mod: boolean;

--- a/bot/commands/index.ts
+++ b/bot/commands/index.ts
@@ -16,6 +16,7 @@ import { ICommandHandler, OnlineState } from './iCommandHandler';
 import { LastRaidCommand } from './lastRaidCommand';
 import { LastSubCommand } from './lastSubCommand';
 import { LurkCommand, UnLurkCommand, WhoIsLurkingCommand } from './lurkCommands';
+import ManageCommand from './manage.command';
 import { ShoutOutCommand } from './shoutOutCommand';
 import { SocialsCommand } from './socialsCommand';
 import ThrowCommand from './throwCommand';
@@ -44,6 +45,7 @@ export {
     LurkCommand,
     UnLurkCommand,
     WhoIsLurkingCommand,
+    ManageCommand,
     ShoutOutCommand,
     SocialsCommand,
     ThrowCommand,

--- a/bot/commands/manage.command.spec.ts
+++ b/bot/commands/manage.command.spec.ts
@@ -1,0 +1,67 @@
+import 'reflect-metadata';
+import { ChatUser } from '@twurple/chat';
+import ManageCommand, { replies } from './manage.command';
+import { mockChatClient, mockLogger } from '../../tests/common.mocks';
+import PhraseService, { PhraseUpdateResult } from '../utilities/phrase.service';
+
+describe('ManageCommand', () => {
+    const channel = 'TestChannel';
+    const command = 'TestCommand';
+    const user = <ChatUser>{
+        displayName: 'TestUser',
+    };
+
+    const mockSetCommandTemplate = jest.fn();
+    const mockPhraseService = <unknown>{
+        setCommandTemplate: mockSetCommandTemplate,
+    } as PhraseService;
+
+    let subject: ManageCommand;
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        subject = new ManageCommand(
+            mockChatClient,
+            mockPhraseService,
+            mockLogger,
+        );
+    });
+
+    it.each(Object.keys(replies) as PhraseUpdateResult[])(
+        'replies correctly for %s result',
+        async result => {
+            // Arrange
+            const updateCommand = 'CommandToUpdate';
+            const updateTemplate = 'TestTemplate';
+            const message = `!command edit ${updateCommand} ${updateTemplate}`;
+            const args: any[] = [
+                updateCommand,
+                updateTemplate,
+            ];
+
+            mockSetCommandTemplate.mockReturnValue(result);
+
+            // Act
+            await subject.handle(channel, command, user, message, args);
+
+            // Assert
+            expect(mockSetCommandTemplate).toHaveBeenCalledWith(updateCommand, updateTemplate);
+            expect(mockChatClient.say).toHaveBeenCalledWith(channel, replies[result](updateCommand));
+        },
+    );
+
+    it('propagates unexpected service errors without replying', async () => {
+        // Arrange
+        const message = '!command edit about some new template';
+        const args = ['about', 'some new template'];
+
+        mockSetCommandTemplate.mockRejectedValue(new Error('connection lost'));
+
+        // Act & Assert
+        await expect(subject.handle(channel, command, user, message, args))
+            .rejects.toThrow('connection lost');
+
+        expect(mockChatClient.say).not.toHaveBeenCalled();
+    });
+});

--- a/bot/commands/manage.command.ts
+++ b/bot/commands/manage.command.ts
@@ -1,0 +1,49 @@
+import { inject, injectable } from 'inversify';
+import { ChatClient, ChatUser } from '@twurple/chat';
+import winston from 'winston';
+import { ICommandHandler, OnlineState } from './iCommandHandler';
+import InjectionTypes from '../../dependency-management/types';
+import PhraseService, { PhraseUpdateResult } from '../utilities/phrase.service';
+
+export const replies: Record<PhraseUpdateResult, (name: string) => string> = {
+    updated: name => `Command ${name} phrase was updated`,
+    updateFailed: name => `Command ${name} phrase failed to update`,
+    invalidInput: () => 'Invalid input: both [name] and [template] are required',
+    invalidTemplate: name => `Invalid template for command '${name}'.`,
+    notEditable: name => `Command ${name} does not have an editable phrase`,
+};
+
+//
+// Suggested Trigger: !command <verb> <name> [args]
+//
+@injectable()
+export default class ManageCommand implements ICommandHandler {
+    exp: RegExp = /^!(command|cmd) edit ([\w.]+) (.+)$/i;
+    timeout: number = 10;
+    mod: boolean = true;
+    vip: boolean = false;
+    artist: boolean = false;
+    founder: boolean = false;
+    subscriber: boolean = false;
+    follower: boolean = false;
+    viewer: boolean = false;
+    isGlobalCommand: boolean = false;
+    restriction: OnlineState = 'always';
+
+    constructor(
+        @inject(ChatClient) private chatClient: ChatClient,
+        @inject(PhraseService) private phraseService: PhraseService,
+        @inject(InjectionTypes.Logger) private logger: winston.Logger,
+    ) { }
+
+    async handle(channel: string, commandName: string, userstate: ChatUser, message: string, args?: any): Promise<void> {
+        const name = args[0];
+        const template = args[1];
+
+        const result = await this.phraseService.setCommandTemplate(name, template);
+
+        this.chatClient.say(channel, replies[result](name));
+
+        this.logger.info(`* Executed ${commandName} in ${channel} || ${userstate.displayName} > ${message}`);
+    }
+}

--- a/bot/utilities/default-phrases.ts
+++ b/bot/utilities/default-phrases.ts
@@ -1,0 +1,5 @@
+export const defaultPhrases = {
+    about: `I'm middleware between you and boredom - assembled from leftover npm packages and one caffeinated decision at 2am. I have strong opinions, weaker error handling, and a Postgres database that remembers absolutely everything.`,
+} as const;
+
+export type PhraseKey = keyof typeof defaultPhrases;

--- a/bot/utilities/default-phrases.ts
+++ b/bot/utilities/default-phrases.ts
@@ -1,5 +1,7 @@
 export const defaultPhrases = {
     about: `I'm middleware between you and boredom - assembled from leftover npm packages and one caffeinated decision at 2am. I have strong opinions, weaker error handling, and a Postgres database that remembers absolutely everything.`,
+    dividebyzero: `Sorry I am too smart for your silly games!`,
+    drink: `Cheering 500 bits and Timy will do a shot. Max 8 per stream.`,
 } as const;
 
 export type PhraseKey = keyof typeof defaultPhrases;

--- a/bot/utilities/phrase.service.spec.ts
+++ b/bot/utilities/phrase.service.spec.ts
@@ -1,0 +1,184 @@
+import 'reflect-metadata';
+import { PostgreSqlContainer, StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import Database, { IDatabaseConfiguration } from '../../database/database';
+import PhraseService from './phrase.service';
+import { mockLogger } from '../../tests/common.mocks';
+import { defaultPhrases } from './default-phrases';
+import { CommandPhrase } from '../../database';
+
+describe('Phrase.Service (postgres)', () => {
+    let container: StartedPostgreSqlContainer;
+    let databaseConfiguration: IDatabaseConfiguration;
+
+    let subject: PhraseService;
+
+    beforeAll(async () => {
+        try {
+            container = await new PostgreSqlContainer('postgres:latest').start();
+        } catch (error: any) {
+            const message = error instanceof Error ? error.message : String(error);
+
+            if (message.includes('401') || message.includes('authentication required')) {
+                throw new Error([
+                    'Docker registry authentication failed while pulling the postgres image.',
+                    'Local Docker Hub credentials are stale: run `docker login`, then rerun.',
+                    `Original error: ${message}`,
+                ].join(' '));
+            }
+
+            throw error;
+        }
+
+        databaseConfiguration = {
+            database: container.getDatabase(),
+            host: container.getHost(),
+            username: container.getUsername(),
+            password: container.getPassword(),
+            port: container.getPort(),
+        };
+    }, 120_000);
+
+    afterAll(async () => {
+        await container.stop();
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('Valid Database object', () => {
+        let database: Database;
+
+        beforeAll(async () => {
+            database = new Database(databaseConfiguration, mockLogger);
+            await database.initialize();
+            subject = new PhraseService();
+        });
+
+        afterAll(async () => {
+            await database.disconnect();
+        });
+
+        beforeEach(async () => {
+            jest.clearAllMocks();
+            await CommandPhrase.destroy({ where: {}, force: true });
+            await subject.initialize();
+        });
+
+        describe('initialize()', () => {
+            it('seeds row, gets installed default', async () => {
+                // Arrange - beforeEach()
+                // Act
+                const result = subject.getCommandTemplate('about');
+
+                // Assert
+                expect(result).toBe(defaultPhrases.about);
+            });
+            it('should not seed twice', async () => {
+                // Arrange
+                const editedTemplate = 'edited template';
+
+                // Act
+                await subject.initialize();
+                await subject.setCommandTemplate('about', editedTemplate);
+                await subject.initialize();
+                const result = subject.getCommandTemplate('about');
+                const rowCount = await CommandPhrase.count({ where: { commandName: 'about' } });
+
+                // Assert
+                expect(result).toBe(editedTemplate);
+                expect(rowCount).toBe(1);
+            });
+        });
+        describe('getCommandTemplate', () => {
+            it('should return the command (cache)', () => {
+                // Arrange - beforeEach()
+                // Act
+                const result = subject.getCommandTemplate('about');
+
+                // Assert
+                expect(result).toBe(defaultPhrases.about);
+            });
+            it('should return undefined for invalid commandName', () => {
+                // Arrange - beforeEach()
+                // Act
+                const result = subject.getCommandTemplate('');
+
+                // Assert
+                expect(result).toBe(undefined);
+            });
+            it('should return undefined for unknown command', () => {
+                // Arrange - beforeEach()
+                // Act
+                const result = subject.getCommandTemplate('unknown');
+
+                // Assert
+                expect(result).toBe(undefined);
+            });
+        });
+        describe('setCommandTemplate()', () => {
+            it('should return false with empty commandName', async () => {
+                // Arrange - beforeEach()
+                // Act
+                const result = await subject.setCommandTemplate('', 'Valid template...');
+
+                // Assert
+                expect(result).toBe(false);
+            });
+            it('should return false with empty template', async () => {
+                // Arrange - beforeEach()
+                // Act
+                const result = await subject.setCommandTemplate('ValidKey', '');
+
+                // Assert
+                expect(result).toBe(false);
+            });
+            it('row updated and gets new template', async () => {
+                // Arrange
+                const editedTemplate = 'edited template';
+
+                // Act
+                const result = await subject.setCommandTemplate('about', editedTemplate);
+                const cached = subject.getCommandTemplate('about');
+                const rows = await CommandPhrase.findAll({ where: { commandName: 'about' } });
+
+                // Assert
+                expect(result).toBe(true);
+                expect(cached).toBe(editedTemplate);
+                expect(rows.length).toBe(1);
+                expect(rows[0].template).toBe(editedTemplate);
+            });
+            it('unknown key returns false, cache preserved', async () => {
+                // Arrange
+                const key = 'Unknown';
+                const template = 'edited template...';
+
+                // Act & Assert
+                expect(await subject.setCommandTemplate(key, template)).toBe(false);
+                expect(subject.getCommandTemplate(key)).toBe(undefined);
+            });
+            it('invalid template (too short) rejected', async () => {
+                // Arrange
+                const badtemplate = 'BAD!';
+
+                // Act
+                const result = await subject.setCommandTemplate('about', badtemplate);
+
+                // Assert
+                expect(result).toBe(false);
+                expect(subject.getCommandTemplate('about')).toBe(defaultPhrases.about);
+            });
+            it('non-validation error propagates', async () => {
+                // Arrange
+                const spy = jest.spyOn(CommandPhrase, 'updateCommandTemplate')
+                    .mockRejectedValueOnce(new Error('connection lost'));
+
+                // Act & Assert
+                await expect(subject.setCommandTemplate('about', 'valid template text'))
+                    .rejects.toThrow('connection lost');
+
+                spy.mockRestore();
+            });
+        });
+    });
+});

--- a/bot/utilities/phrase.service.spec.ts
+++ b/bot/utilities/phrase.service.spec.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata';
 import { PostgreSqlContainer, StartedPostgreSqlContainer } from '@testcontainers/postgresql';
 import Database, { IDatabaseConfiguration } from '../../database/database';
-import PhraseService from './phrase.service';
+import PhraseService, { PhraseUpdateResult } from './phrase.service';
 import { mockLogger } from '../../tests/common.mocks';
 import { defaultPhrases } from './default-phrases';
 import { CommandPhrase } from '../../database';
@@ -52,7 +52,7 @@ describe('Phrase.Service (postgres)', () => {
         beforeAll(async () => {
             database = new Database(databaseConfiguration, mockLogger);
             await database.initialize();
-            subject = new PhraseService();
+            subject = new PhraseService(mockLogger);
         });
 
         afterAll(async () => {
@@ -123,7 +123,7 @@ describe('Phrase.Service (postgres)', () => {
                 const result = await subject.setCommandTemplate('', 'Valid template...');
 
                 // Assert
-                expect(result).toBe(false);
+                expect(result).toBe<PhraseUpdateResult>('invalidInput');
             });
             it('should return false with empty template', async () => {
                 // Arrange - beforeEach()
@@ -131,7 +131,7 @@ describe('Phrase.Service (postgres)', () => {
                 const result = await subject.setCommandTemplate('ValidKey', '');
 
                 // Assert
-                expect(result).toBe(false);
+                expect(result).toBe<PhraseUpdateResult>('invalidInput');
             });
             it('row updated and gets new template', async () => {
                 // Arrange
@@ -143,7 +143,7 @@ describe('Phrase.Service (postgres)', () => {
                 const rows = await CommandPhrase.findAll({ where: { commandName: 'about' } });
 
                 // Assert
-                expect(result).toBe(true);
+                expect(result).toBe<PhraseUpdateResult>('updated');
                 expect(cached).toBe(editedTemplate);
                 expect(rows.length).toBe(1);
                 expect(rows[0].template).toBe(editedTemplate);
@@ -154,7 +154,7 @@ describe('Phrase.Service (postgres)', () => {
                 const template = 'edited template...';
 
                 // Act & Assert
-                expect(await subject.setCommandTemplate(key, template)).toBe(false);
+                expect(await subject.setCommandTemplate(key, template)).toBe<PhraseUpdateResult>('notEditable');
                 expect(subject.getCommandTemplate(key)).toBe(undefined);
             });
             it('invalid template (too short) rejected', async () => {
@@ -165,7 +165,7 @@ describe('Phrase.Service (postgres)', () => {
                 const result = await subject.setCommandTemplate('about', badtemplate);
 
                 // Assert
-                expect(result).toBe(false);
+                expect(result).toBe<PhraseUpdateResult>('invalidTemplate');
                 expect(subject.getCommandTemplate('about')).toBe(defaultPhrases.about);
             });
             it('non-validation error propagates', async () => {

--- a/bot/utilities/phrase.service.ts
+++ b/bot/utilities/phrase.service.ts
@@ -1,11 +1,24 @@
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 import { ValidationError } from 'sequelize';
+import winston from 'winston';
 import { CommandPhrase } from '../../database';
-import { defaultPhrases, PhraseKey } from './default-phrases';
+import { defaultPhrases } from './default-phrases';
+import InjectionTypes from '../../dependency-management/types';
+
+export type PhraseUpdateResult =
+    'updated' |
+    'invalidInput' |
+    'notEditable' |
+    'invalidTemplate' |
+    'updateFailed';
 
 @injectable()
 export default class PhraseService {
     private phraseCache = new Map<string, string>();
+
+    constructor(
+        @inject(InjectionTypes.Logger) private logger: winston.Logger,
+    ) { }
 
     async initialize(): Promise<void> {
         await CommandPhrase.seed(defaultPhrases);
@@ -29,9 +42,13 @@ export default class PhraseService {
      * @param template new template value for the Command
      * @returns boolean flag denoting if the provided command was updated
      */
-    async setCommandTemplate(commandName: string, template: string): Promise<boolean> {
+    async setCommandTemplate(commandName: string, template: string): Promise<PhraseUpdateResult> {
         if (!commandName || !template) {
-            return false;
+            return 'invalidInput';
+        }
+
+        if (!this.phraseCache.has(commandName)) {
+            return 'notEditable';
         }
 
         try {
@@ -40,15 +57,17 @@ export default class PhraseService {
             if (command) {
                 this.phraseCache.set(commandName, template);
 
-                return true;
+                return 'updated';
             }
+
+            this.logger.warn(` Valid command (${commandName}) database update attempt failed.`);
         } catch (error) {
             if (error instanceof ValidationError) {
-                return false;
+                return 'invalidTemplate';
             }
             throw error;
         }
 
-        return false;
+        return 'updateFailed';
     }
 }

--- a/bot/utilities/phrase.service.ts
+++ b/bot/utilities/phrase.service.ts
@@ -1,0 +1,54 @@
+import { injectable } from 'inversify';
+import { ValidationError } from 'sequelize';
+import { CommandPhrase } from '../../database';
+import { defaultPhrases, PhraseKey } from './default-phrases';
+
+@injectable()
+export default class PhraseService {
+    private phraseCache = new Map<string, string>();
+
+    async initialize(): Promise<void> {
+        await CommandPhrase.seed(defaultPhrases);
+
+        const rows = await CommandPhrase.findAll();
+        this.phraseCache = new Map(rows
+            .map((row): [string, string] => [row.commandName, row.template]));
+    }
+
+    getCommandTemplate(commandName: string): string | undefined {
+        if (!commandName) {
+            return undefined;
+        }
+
+        return this.phraseCache.get(commandName);
+    }
+
+    /**
+     * Update the command with the provided template
+     * @param commandName Command to update
+     * @param template new template value for the Command
+     * @returns boolean flag denoting if the provided command was updated
+     */
+    async setCommandTemplate(commandName: string, template: string): Promise<boolean> {
+        if (!commandName || !template) {
+            return false;
+        }
+
+        try {
+            const command = await CommandPhrase.updateCommandTemplate(commandName, template);
+
+            if (command) {
+                this.phraseCache.set(commandName, template);
+
+                return true;
+            }
+        } catch (error) {
+            if (error instanceof ValidationError) {
+                return false;
+            }
+            throw error;
+        }
+
+        return false;
+    }
+}

--- a/database/database.spec.ts
+++ b/database/database.spec.ts
@@ -136,10 +136,8 @@ describe('Database (postgres)', () => {
         describe('connect()', () => {
             it('fails to connect and logs connection error', async () => {
                 // Arrange - beforeAll()
-                // Act
-                await badDatabase.connect();
-
-                // Assert
+                // Act & Assert
+                await expect(badDatabase.connect()).rejects.toThrow();
                 expect(mockLogger.info).not.toHaveBeenCalled();
                 expect(mockLogger.error).toHaveBeenCalledWith('**Unable to connect to the database**:', expect.anything());
             }, 30_000);
@@ -148,10 +146,8 @@ describe('Database (postgres)', () => {
         describe('sync()', () => {
             it('fails to syncronizes the database', async () => {
                 // Arrange - beforeAll()
-                // Act
-                await badDatabase.sync();
-
-                // Assert
+                // Act & Assert
+                await expect(badDatabase.sync()).rejects.toThrow();
                 expect(mockLogger.info).not.toHaveBeenCalled();
                 expect(mockLogger.error).toHaveBeenCalledWith('**DB Sync Failed**:', expect.anything());
             }, 30_000);

--- a/database/database.ts
+++ b/database/database.ts
@@ -7,6 +7,7 @@ import {
     BanEvent,
     ChannelPointRedeem,
     CheerEvent,
+    CommandPhrase,
     DeathCounts,
     FollowEvent,
     LurkingUsers,
@@ -55,6 +56,7 @@ function buildPostgresqlConfig(config: IDatabaseConfiguration): SequelizeOptions
             BanEvent,
             ChannelPointRedeem,
             CheerEvent,
+            CommandPhrase,
             DeathCounts,
             FollowEvent,
             LurkingUsers,
@@ -87,7 +89,10 @@ export default class Database {
     async connect(): Promise<void> {
         await this.validate()
             .then(() => this.logger.info('DB Connection has been established successfully.'))
-            .catch((error: any) => this.logger.error('**Unable to connect to the database**:', error));
+            .catch((error: any) => {
+                this.logger.error('**Unable to connect to the database**:', error);
+                throw error;
+            });
     }
 
     async sync(): Promise<void> {
@@ -95,7 +100,15 @@ export default class Database {
             // sync logging has no diagnostic value
             .sync({ logging: false })
             .then(obj => this.logger.info('DB Sync completed successfully'))
-            .catch((error: any) => this.logger.error('**DB Sync Failed**:', error));
+            .catch((error: any) => {
+                this.logger.error('**DB Sync Failed**:', error);
+                throw error;
+            });
+    }
+
+    async initialize(): Promise<void> {
+        await this.connect();
+        await this.sync();
     }
 
     async validate(): Promise<void> {
@@ -108,8 +121,6 @@ export default class Database {
             .then(() => {
                 this.logger.info('All DB connections have been successfully closed.');
             })
-            .catch((err: any) => {
-                this.logger.error('There were issues disconnecting from the database:', err);
-            });
+            .catch((error: any) => this.logger.error('There were issues disconnecting from the database:', error));
     }
 }

--- a/database/index.ts
+++ b/database/index.ts
@@ -11,11 +11,13 @@ import StreamEventRecord from './models/stream-event-record.dbo';
 import Subscribers from './models/subscribers.dbo';
 import SubscriptionType from './models/subscriptionType';
 import SubscriptionGiftUsers from './models/subscriptionGiftUsers.dbo';
+import CommandPhrase from './models/commandPhrase.dbo';
 
 export {
     BanEvent,
     ChannelPointRedeem,
     CheerEvent,
+    CommandPhrase,
     DeathCounts,
     FollowEvent,
     LurkingUsers,

--- a/database/models/commandPhrase.dbo.ts
+++ b/database/models/commandPhrase.dbo.ts
@@ -1,0 +1,74 @@
+import { Column, DataType, Table, Model } from 'sequelize-typescript';
+import { defaultPhrases, PhraseKey } from '../../bot/utilities/default-phrases';
+
+@Table({
+    tableName: 'CommandPhrase',
+    paranoid: true,
+})
+export default class CommandPhrase extends Model {
+    @Column({
+        allowNull: false,
+        type: DataType.STRING(255),
+        unique: true,
+    })
+    commandName!: string;
+
+    @Column({
+        allowNull: false,
+        type: DataType.TEXT,
+        validate: {
+            notEmpty: true,
+            len: {
+                args: [10, 400],
+                msg: 'template must be 10-400 characters',
+            },
+        },
+        set(value: string) {
+            this.setDataValue('template', value?.trim());
+        },
+    })
+    template!: string;
+
+    static async seed(entries: Record<string, string>): Promise<void> {
+        const records = Object
+            .entries(entries)
+            .map(([commandName, template]) => ({ commandName, template }));
+
+        await CommandPhrase.bulkCreate(
+            records,
+            {
+                ignoreDuplicates: true,
+                validate: true,
+            },
+        );
+    }
+
+    /**
+     * Get the command based on the provided commandName
+     * @param commandName The command name to fetch
+     * @returns The Command based on the provided commandName or null
+     */
+    static async getCommand(commandName: string): Promise<CommandPhrase | null> {
+        return CommandPhrase
+            .findOne({
+                where: {
+                    commandName,
+                },
+            });
+    }
+
+    /**
+     * Update existing command based on the provided template
+     * @param commandName The command name to update
+     * @param template new template value for the Command
+     * @returns boolean flag denoting if the provided command was updated
+     */
+    static async updateCommandTemplate(commandName: string, template: string): Promise<boolean> {
+        const [count] = await CommandPhrase.update(
+            { template },
+            { where: { commandName } },
+        );
+
+        return count === 1;
+    }
+}

--- a/database/models/commandPhrase.dbo.ts
+++ b/database/models/commandPhrase.dbo.ts
@@ -1,5 +1,4 @@
 import { Column, DataType, Table, Model } from 'sequelize-typescript';
-import { defaultPhrases, PhraseKey } from '../../bot/utilities/default-phrases';
 
 @Table({
     tableName: 'CommandPhrase',

--- a/dependency-management/inversify.config.ts
+++ b/dependency-management/inversify.config.ts
@@ -68,6 +68,7 @@ import OverlayServer, { IOverlayServer } from '../bot/overlay/overlay.server';
 import AuthenticationServer, { IAuthenticationServer } from '../bot/auth/auth.server';
 import StreamStateService from '../bot/utilities/stream-state.service';
 import JoinGreetingHandler from '../bot/handlers/join-greeting.handler';
+import PhraseService from '../bot/utilities/phrase.service';
 
 const SAContainer = new Container();
 
@@ -75,6 +76,7 @@ SAContainer.bind<Database>(Database).toSelf().inSingletonScope();
 
 SAContainer.bind<Broadcaster>(Broadcaster).toSelf().inSingletonScope();
 SAContainer.bind<StreamStateService>(StreamStateService).toSelf().inSingletonScope();
+SAContainer.bind<PhraseService>(PhraseService).toSelf().inSingletonScope();
 
 SAContainer.bind<IChatBot>(ChatBot).toSelf().inSingletonScope();
 

--- a/dependency-management/inversify.config.ts
+++ b/dependency-management/inversify.config.ts
@@ -30,6 +30,7 @@ import {
     LurkCommand,
     UnLurkCommand,
     WhoIsLurkingCommand,
+    ManageCommand,
     ShoutOutCommand,
     SocialsCommand,
     UpTimeCommand,
@@ -114,6 +115,7 @@ SAContainer.bind<ICommandHandler>(InjectionTypes.CommandHandlers).to(LastSubComm
 SAContainer.bind<ICommandHandler>(InjectionTypes.CommandHandlers).to(LurkCommand);
 SAContainer.bind<ICommandHandler>(InjectionTypes.CommandHandlers).to(UnLurkCommand);
 SAContainer.bind<ICommandHandler>(InjectionTypes.CommandHandlers).to(WhoIsLurkingCommand);
+SAContainer.bind<ICommandHandler>(InjectionTypes.CommandHandlers).to(ManageCommand);
 SAContainer.bind<ICommandHandler>(InjectionTypes.CommandHandlers).to(ShoutOutCommand);
 SAContainer.bind<ICommandHandler>(InjectionTypes.CommandHandlers).to(SocialsCommand);
 SAContainer.bind<ICommandHandler>(InjectionTypes.CommandHandlers).to(ThrowCommand);

--- a/docs/command-system.md
+++ b/docs/command-system.md
@@ -17,6 +17,7 @@ Commands are discrete units of chat functionality. Each command is a class imple
 ```typescript
 export interface ICommandHandler {
     exp: RegExp;
+    phraseKey?: PhraseKey;
     timeout: number;
     mod: boolean;
     vip: boolean;
@@ -36,6 +37,7 @@ export interface ICommandHandler {
 | Property | Type | Description |
 |---|---|---|
 | `exp` | `RegExp` | Pattern matched against the raw chat message. The first capture group is the command name; subsequent groups become `args`. |
+| `phraseKey` | `PhraseKey?` | Key into the phrase table for commands with database-backed response text. Omit for commands with computed or fixed responses. |
 | `timeout` | `number` | Cooldown period in seconds. Privileged users (mod, VIP, subscriber, etc.) receive half this duration. |
 | `mod` | `boolean` | Allow channel moderators. |
 | `vip` | `boolean` | Allow VIPs. |
@@ -93,6 +95,38 @@ otherwise            -> denied
 The `timeout` value is the base cooldown in seconds. Privileged users (founder, mod, subscriber, VIP, artist) receive `timeout / 2`. The broadcaster has no cooldown.
 
 Global cooldowns (`isGlobalCommand: true`) are shared - once any user triggers the cooldown, the command is unavailable to everyone until the period expires.
+
+---
+
+## Database-Backed Phrases
+
+Command response text can live in the database (`CommandPhrase` table) instead of the class, making it editable at runtime without a redeploy.
+
+* Default text is declared in `bot/utilities/default-phrases.ts`. The `PhraseKey` type is derived from its keys, so a command's `phraseKey` must have a matching entry or the build fails.
+* On startup, `PhraseService.initialize()` seeds any missing rows from the defaults. Existing rows are never overwritten - edits survive restarts.
+* Phrases are cached in memory at startup and kept in sync on writes. Reads never hit the database per-message. Rows edited directly in the database are not visible until restart.
+* A command reads its phrase via `PhraseService.getCommandTemplate(this.phraseKey)`, falling back to its `defaultPhrases` entry if the lookup misses.
+
+### Making a command's phrase editable
+
+1. Add an entry to `defaultPhrases` with the command's trigger word as the key
+2. Declare `phraseKey` on the command class referencing that key
+3. Inject `PhraseService` and read the template in `handle`
+
+---
+
+## Editing Phrases from Chat
+
+`ManageCommand` (`bot/commands/manage.command.ts`) provides runtime phrase editing. Moderator or broadcaster only.
+
+    !command edit <name> <template>
+    !cmd edit <name> <template>
+
+* `<name>` is the phrase key (e.g. `about`); `<template>` is free text to end of line
+* Only commands with an existing phrase row are editable - anything else replies "does not have an editable phrase"
+* Templates are trimmed and validated (length bounds); invalid templates are rejected with a chat reply and the stored phrase is unchanged
+* Known behavior: a message missing the template entirely (`!command edit about`) does not match the pattern and is silently ignored
+* Add/remove verbs are not yet implemented - the phrase set is defined by `default-phrases.ts`
 
 ---
 

--- a/tests/common.mocks.ts
+++ b/tests/common.mocks.ts
@@ -1,21 +1,26 @@
 import { ApiClient } from '@twurple/api';
 import { ChatClient } from '@twurple/chat';
 import winston from 'winston';
+import PhraseService from '../bot/utilities/phrase.service';
 
-const mockChatClient: ChatClient = <unknown>{
+export const mockChatClient: ChatClient = <unknown>{
     say: jest.fn(),
 } as ChatClient;
 
-const mockApiClient: ApiClient = <unknown>{
+export const mockApiClient: ApiClient = <unknown>{
     streams: {
         getStreamByUserName: jest.fn(),
     },
 } as ApiClient;
 
-const mockLogger: winston.Logger = <unknown>{
+export const mockLogger: winston.Logger = <unknown>{
     info: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
 } as winston.Logger;
 
-export { mockChatClient, mockApiClient, mockLogger };
+export const mockPhraseService = <unknown>{
+    initialize: jest.fn(),
+    getCommandTemplate: jest.fn(),
+    setCommandTemplate: jest.fn(),
+} as jest.Mocked<PhraseService>;


### PR DESCRIPTION
## Summary

Establishes the database-backed phrase system: command response text lives
in Postgres, cached in memory, and is editable live from chat by mods - no
redeploy for wording changes.

* `CommandPhrase` model (validated, trimmed, unique-keyed) + `PhraseService`
  with startup seeding and write-through cache
* `!command edit <name> <template>` (mod+) with typed result feedback in chat
* Migrated static commands: `about` (pilot), `DivideByZero`, `drink`
* Fail-fast DB bootstrap (connect/sync rethrow, accurate exit logging)
* Integration test suites on testcontainers (PhraseService, Database);
  command specs converted to direct instantiation with shared mocks
* `docs/command-system.md`: phrase system + chat editing sections

## Scope note

Remaining phrase work is distributed to PR-sized successors: 
* #119 (variants + add verb + socials) 
* #120 (resolver + simple templated) 
* #121 (branched templated)
* #122 (config editing)
* #123 (remove verb)
* #124 (hygiene)

## Test plan

- [x] `npm test` green (unit + testcontainers integration)
- [x] Live-verified: `!about` served from DB; `!command edit about ...` takes
  effect immediately; restart preserves edits

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
