### PR TITLE
Feature/123 remove verb for command management

### DIFF
--- a/bot/commands/manage.command.spec.ts
+++ b/bot/commands/manage.command.spec.ts
@@ -2,13 +2,29 @@ import 'reflect-metadata';
 import { ChatUser } from '@twurple/chat';
 import ManageCommand, {
     InsertReplies,
+    RemoveReplies,
     UnsupportedMessage,
     UpdateReplies,
 } from './manage.command';
 import { mockChatClient, mockCommandResponseService, mockLogger } from '../../tests/common.mocks';
-import { CommandTextInsertResult, CommandTextUpdateResult } from '../utilities/command-response.service';
+import {
+    CommandTextInsertResult,
+    CommandTextRemoveResult,
+    CommandTextUpdateResult,
+} from '../utilities/command-response.service';
 
-const messageFn = (subcommand: string, compoundName: string, text: string) => `!command ${subcommand} ${compoundName} ${text}`;
+/** Utility method for constructing command message inline with ManageCommand */
+const messageFn = (subcommand: string, compoundName: string, text: string = '') => `!command ${subcommand} ${compoundName} ${text}`.trim();
+
+/** Utility method for extracting components to properly invoke the handler */
+const parseComand = (message: string, expression: RegExp): string[] => {
+    const result = message.trim().match(expression)!;
+    if (result) {
+        const [, ...[, ...args]] = result;
+        return args;
+    }
+    return [];
+};
 
 describe('ManageCommand', () => {
     const channel = 'TestChannel';
@@ -33,13 +49,9 @@ describe('ManageCommand', () => {
     it('Unsupported excessive subvariant (3 generations)', async () => {
         // Arrange
         const compoundName = 'Command.Variant.UnsupportedVariantLevel';
-        const subCommand = 'invariant';
+        const subCommand = 'add';
         const message = messageFn(subCommand, compoundName, text);
-        const args: any[] = [
-            subCommand,
-            compoundName,
-            text,
-        ];
+        const args = parseComand(message, subject.exp);
 
         // Act
         await subject.handle(channel, command, user, message, args);
@@ -104,9 +116,9 @@ describe('ManageCommand', () => {
                 // Arrange
                 const compoundName = 'Command.Variant';
                 const [name, variant] = compoundName.split('.');
-                const message = `!command edit ${compoundName} ${text}`;
+                const message = messageFn(subCommand, compoundName, text);
                 const args: any[] = [
-                    'edit',
+                    subCommand,
                     compoundName,
                     text,
                 ];
@@ -132,6 +144,52 @@ describe('ManageCommand', () => {
 
             mockCommandResponseService
                 .setCommandText
+                .mockRejectedValue(new Error('connection lost'));
+
+            // Act & Assert
+            await expect(subject.handle(channel, command, user, message, args))
+                .rejects.toThrow('connection lost');
+
+            expect(mockChatClient.say).not.toHaveBeenCalled();
+        });
+    });
+    describe('Remove Command', () => {
+        const subCommand = 'remove';
+
+        it.each(Object.keys(RemoveReplies) as CommandTextRemoveResult[])(
+            'replies correctly for %s result',
+            async result => {
+                // Arrange
+                const compoundName = 'Command.Variant';
+                const [name, variant] = compoundName.split('.');
+                const message = messageFn(subCommand, compoundName);
+                const args: any[] = [
+                    subCommand,
+                    compoundName,
+                    text,
+                ];
+
+                mockCommandResponseService
+                    .removeCommandText
+                    .mockResolvedValue(result);
+
+                // Act
+                await subject.handle(channel, command, user, message, args);
+
+                // Assert
+                expect(mockCommandResponseService.removeCommandText)
+                    .toHaveBeenCalledWith(name, variant);
+                expect(mockChatClient.say).toHaveBeenCalledWith(channel, RemoveReplies[result](compoundName));
+            },
+        );
+
+        it('propagates unexpected service errors without replying', async () => {
+            // Arrange
+            const message = messageFn(subCommand, command, text);
+            const args = [subCommand, command, text];
+
+            mockCommandResponseService
+                .removeCommandText
                 .mockRejectedValue(new Error('connection lost'));
 
             // Act & Assert

--- a/bot/commands/manage.command.ts
+++ b/bot/commands/manage.command.ts
@@ -7,6 +7,7 @@ import CommandResponseService, {
     CommandTextValidationResult,
     CommandTextInsertResult,
     CommandTextUpdateResult,
+    CommandTextRemoveResult,
 } from '../utilities/command-response.service';
 
 export const GenericReplies: Record<CommandTextValidationResult, (name: string) => string> = {
@@ -28,6 +29,13 @@ export const UpdateReplies: Record<CommandTextUpdateResult, (name: string) => st
     updateFailed: name => `Command ${name} text failed to update`,
 };
 
+export const RemoveReplies: Record<CommandTextRemoveResult, (name: string) => string> = {
+    ...GenericReplies,
+    notFound: name => `Command ${name} was not found`,
+    removed: name => `Command ${name} was removed`,
+    removeFailed: name => `Command ${name} failed to be removed`,
+};
+
 export const UnsupportedMessage = (name: string) => `${name} is not a valid command`;
 
 //
@@ -35,7 +43,7 @@ export const UnsupportedMessage = (name: string) => `${name} is not a valid comm
 //
 @injectable()
 export default class ManageCommand implements ICommandHandler {
-    exp: RegExp = /^!(command|cmd) (add|edit) ([\w.]+) (.+)$/i;
+    exp: RegExp = /^!(command|cmd) (add|edit|remove) ([\w.]+)(?: (.+))?$/i;
     timeout: number = 10;
     mod: boolean = true;
     vip: boolean = false;
@@ -71,6 +79,11 @@ export default class ManageCommand implements ICommandHandler {
                 case 'edit': {
                     const result = await this.commandResponseService.setCommandText(name, text, variant);
                     this.chatClient.say(channel, UpdateReplies[result](compoundName));
+                    break;
+                }
+                case 'remove': {
+                    const result = await this.commandResponseService.removeCommandText(name, variant);
+                    this.chatClient.say(channel, RemoveReplies[result](compoundName));
                     break;
                 }
             }

--- a/bot/utilities/command-response.service.spec.ts
+++ b/bot/utilities/command-response.service.spec.ts
@@ -6,6 +6,7 @@ import CommandResponseService, {
     CommandTextValidationResult,
     CommandTextInsertResult,
     CommandTextUpdateResult,
+    CommandTextRemoveResult,
 } from './command-response.service';
 import { mockLogger } from '../../tests/common.mocks';
 import { defaultResponses } from './default-responses';
@@ -421,6 +422,30 @@ describe('CommandResponse.Service (postgres)', () => {
                 expect(untouched.length).toBe(1);
                 expect(untouched.map(x => x.variant)).not.toContain(testVariants[1]);
             });
+            it(`row 'inserted' and gets new text (restored)`, async () => {
+                // Arrange - beforeEach()
+                await seedVariants(testCommand, testVariants);
+
+                // Act
+                const sideeffect = await subject.removeCommandText(testCommand, testVariants[1]);
+                const initial = subject.getCommandText(testCommand, testVariants[1]);
+                const result = await subject.addCommandText(testCommand, validText, testVariants[1]);
+                const cached = subject.getCommandText(testCommand, testVariants[1]);
+                const rows = await CommandResponse.findAll({ where: { commandName: testCommand } });
+
+                const inserted = rows.find(r => r.variant === testVariants[1]);
+                const untouched = rows.filter(r => r.variant !== testVariants[1]);
+
+                // Assert
+                expect(sideeffect).toBe<CommandTextRemoveResult>('removed');
+                expect(result).toBe<CommandTextInsertResult>('inserted');
+                expect(initial).toBe(undefined);
+                expect(cached).toBe(validText);
+                expect(rows.length).toBe(2);
+                expect(inserted?.text).toBe(validText);
+                expect(untouched.length).toBe(1);
+                expect(untouched.map(x => x.variant)).not.toContain(testVariants[1]);
+            });
             it('invalid text (already exists) rejected', async () => {
                 // Arrange
                 const spy = jest.spyOn(CommandResponse, 'addCommandText')
@@ -452,6 +477,82 @@ describe('CommandResponse.Service (postgres)', () => {
 
                 // Act & Assert
                 await expect(subject.addCommandText(testCommand, validText, testVariants[0]))
+                    .rejects.toThrow('connection lost');
+
+                spy.mockRestore();
+            });
+        });
+        describe('removeCommandText()', () => {
+            it('should return false with empty commandName', async () => {
+                // Arrange - beforeEach()
+                // Act
+                const result = await subject.removeCommandText('', 'ValidVariant');
+
+                // Assert
+                expect(result).toBe<CommandTextValidationResult>('invalidInput');
+            });
+            it('should return invalidInput with empty variant', async () => {
+                // Arrange - beforeEach()
+                // Act
+                const result = await subject.removeCommandText(validName);
+
+                // Assert
+                expect(result).toBe<CommandTextValidationResult>('invalidInput');
+            });
+            it('command/variant not in cache returns notFound', async () => {
+                // Arrange
+                await seedVariants(testCommand, testVariants);
+
+                // Act
+                const result = await subject.removeCommandText(testCommand, 'unknown');
+
+                // Assert
+                expect(result).toBe<CommandTextRemoveResult>('notFound');
+            });
+            it('should remove record from database records and cache', async () => {
+                // Arrange
+                await seedVariants(testCommand, testVariants);
+
+                // Act
+                const result = await subject.removeCommandText(testCommand, testVariants[0]);
+                const rows = await CommandResponse.findAll({ where: { commandName: testCommand } });
+                const variants = subject.getCommandVariants(testCommand);
+
+                // Assert
+                expect(result).toBe<CommandTextRemoveResult>('removed');
+                expect(rows.length).toBe(testVariants.length - 1);
+                expect(rows).not.toContainEqual(expect.objectContaining({ commandName: testCommand, variant: testVariants[0] }));
+                expect(variants.length).toBe(testVariants.length - 1);
+                expect(variants).not.toContain(testVariants[0]);
+            });
+            it('should not have removed valid command/variant from database or cache', async () => {
+                // Arrange
+                await seedVariants(testCommand, testVariants);
+                const spy = jest.spyOn(CommandResponse, 'removeCommandText')
+                    .mockResolvedValue(false);
+
+                // Act
+                const result = await subject.removeCommandText(testCommand, testVariants[0]);
+                const rows = await CommandResponse.findAll({ where: { commandName: testCommand } });
+                const variants = subject.getCommandVariants(testCommand);
+
+                // Assert
+                expect(result).toBe<CommandTextRemoveResult>('removeFailed');
+                expect(rows.length).toBe(testVariants.length);
+                expect(rows).toContainEqual(expect.objectContaining({ commandName: testCommand, variant: testVariants[0] }));
+                expect(variants.length).toBe(testVariants.length);
+                expect(variants).toContain(testVariants[0]);
+
+                spy.mockRestore();
+            });
+            it('thrown error propagates', async () => {
+                // Arrange
+                await seedVariants(testCommand, testVariants);
+                const spy = jest.spyOn(CommandResponse, 'removeCommandText')
+                    .mockRejectedValueOnce(new Error('connection lost'));
+
+                // Act & Assert
+                await expect(subject.removeCommandText(testCommand, testVariants[0]))
                     .rejects.toThrow('connection lost');
 
                 spy.mockRestore();

--- a/bot/utilities/command-response.service.ts
+++ b/bot/utilities/command-response.service.ts
@@ -19,6 +19,11 @@ export type CommandTextInsertResult = CommandTextValidationResult |
     'invalidCommandName' |
     'inserted';
 
+export type CommandTextRemoveResult = CommandTextValidationResult |
+    'notFound' |
+    'removed' |
+    'removeFailed';
+
 type ResponseEntry = { variant: string; text: string };
 
 const cacheKey = (name: string, variant: string = ''): string => (variant ? `${name}.${variant}` : name);
@@ -64,6 +69,13 @@ export default class CommandResponseService {
         return this.responseCache.get(cacheKey(commandName, variant))?.text;
     }
 
+    /**
+     * Add the command/variant with the provided text
+     * @param commandName Command to add
+     * @param text new text value for the Command
+     * @param variant The command name variant to add
+     * @returns boolean flag denoting if the provided command/variant was created
+     */
     async addCommandText(commandName: string, text: string, variant: string = ''): Promise<CommandTextInsertResult> {
         if (!commandName || !text || !variant) {
             return 'invalidInput';
@@ -78,7 +90,13 @@ export default class CommandResponseService {
         }
 
         try {
-            await CommandResponse.addCommandText(commandName, text, variant);
+            const restored = await CommandResponse.restoreCommandText(commandName, variant);
+
+            if (restored) {
+                await CommandResponse.updateCommandText(commandName, text, variant);
+            } else {
+                await CommandResponse.addCommandText(commandName, text, variant);
+            }
 
             this.responseCache.set(cacheKey(commandName, variant), { variant, text });
 
@@ -95,7 +113,7 @@ export default class CommandResponseService {
     }
 
     /**
-     * Update the command with the provided text
+     * Update the command/variant with the provided text
      * @param commandName Command to update
      * @param text new text value for the Command
      * @param variant The command name variant to update
@@ -128,5 +146,31 @@ export default class CommandResponseService {
         }
 
         return 'updateFailed';
+    }
+
+    /**
+     * Remove (soft-delete) the command/variant
+     * @param commandName Command to remove
+     * @param variant The command variant to remove
+     * @returns boolean flag denoting if the provided command/variant was removed
+     */
+    async removeCommandText(commandName: string, variant: string = ''): Promise<CommandTextRemoveResult> {
+        if (!commandName || !variant) {
+            return 'invalidInput';
+        }
+
+        if (!this.responseCache.has(cacheKey(commandName, variant))) {
+            return 'notFound';
+        }
+
+        const result = await CommandResponse.removeCommandText(commandName, variant);
+
+        if (result) {
+            this.responseCache.delete(cacheKey(commandName, variant));
+            return 'removed';
+        }
+
+        this.logger.warn(`Valid command (${cacheKey(commandName, variant)}) database remove attempt failed.`);
+        return 'removeFailed';
     }
 }

--- a/database/models/command-response.dbo.ts
+++ b/database/models/command-response.dbo.ts
@@ -43,13 +43,14 @@ export default class CommandResponse extends Model {
             .entries(entries)
             .map(([commandName, text]) => ({ commandName, text }));
 
-        await CommandResponse.bulkCreate(
-            records,
-            {
-                ignoreDuplicates: true,
-                validate: true,
-            },
-        );
+        await CommandResponse
+            .bulkCreate(
+                records,
+                {
+                    ignoreDuplicates: true,
+                    validate: true,
+                },
+            );
     }
 
     /**
@@ -58,12 +59,12 @@ export default class CommandResponse extends Model {
      * @param variant The command name variant to fetch
      * @returns The Command based on the provided commandName or null
      */
-    static async getCommandText(commandName: string, variant?: string): Promise<CommandResponse | null> {
+    static async getCommandText(commandName: string, variant: string = ''): Promise<CommandResponse | null> {
         return CommandResponse
             .findOne({
                 where: {
                     commandName,
-                    variant: variant ?? null,
+                    variant,
                 },
             });
     }
@@ -91,14 +92,15 @@ export default class CommandResponse extends Model {
      * @returns The created command if successful, rejected error otherwise
      */
     static async addCommandText(commandName: string, text: string, variant: string = ''): Promise<CommandResponse> {
-        return CommandResponse.create({
-            commandName,
-            variant,
-            text,
-        }, {
-            isNewRecord: true,
-            validate: true,
-        });
+        return CommandResponse
+            .create({
+                commandName,
+                variant,
+                text,
+            }, {
+                isNewRecord: true,
+                validate: true,
+            });
     }
 
     /**
@@ -109,16 +111,66 @@ export default class CommandResponse extends Model {
      * @returns boolean flag denoting if the provided command was updated
      */
     static async updateCommandText(commandName: string, text: string, variant: string = ''): Promise<boolean> {
-        const [count] = await CommandResponse.update(
-            { text },
-            {
+        const [count] = await CommandResponse
+            .update(
+                { text },
+                {
+                    where: {
+                        commandName,
+                        variant,
+                    },
+                },
+            );
+
+        return count === 1;
+    }
+
+    /**
+     * Soft-Delete specified command, if present
+     * @param commandName The command name to remove
+     * @param variant The command name variant to remove
+     * @returns boolean flag denoting if the provided command was removed
+     */
+    static async removeCommandText(commandName: string, variant: string = ''): Promise<boolean> {
+        const count = await CommandResponse
+            .destroy({
                 where: {
                     commandName,
                     variant,
                 },
-            },
-        );
+            });
 
         return count === 1;
+    }
+
+    /**
+     * Restore specified command, if present
+     * @param commandName The command name to restore
+     * @param variant The command name variant to restore
+     * @returns boolean flag denoting if the provided command was restored
+     */
+    static async restoreCommandText(commandName: string, variant: string = ''): Promise<boolean> {
+        const command = await CommandResponse
+            .findOne({
+                where: {
+                    commandName,
+                    variant,
+                },
+                paranoid: false,
+            });
+
+        if (command?.deletedAt) {
+            await CommandResponse
+                .restore({
+                    where: {
+                        commandName,
+                        variant,
+                    },
+                });
+
+            return true;
+        }
+
+        return false;
     }
 }

--- a/docs/command-system.md
+++ b/docs/command-system.md
@@ -136,26 +136,29 @@ Whether a `commandName` value resolves to a single fixed reponse or a family of 
 
 ## Editing Reponses from Chat
 
-`ManageCommand` (`bot/commands/manage.command.ts`) provides runtime response editing. Moderator or broadcaster only.
+`ManageCommand` (`bot/commands/manage.command.ts`) provides runtime response management. Moderator or broadcaster only.
 
     !command add <name>[.<variant>] <text>
     !command edit <name>[.<variant>] <text>
+    !command remove <name>.<variant>
     !cmd add <name>[.<variant>] <text>
     !cmd edit <name>[.<variant>] <text>
+    !cmd remove <name>.<variant>
 
 * `<name>` is a `commandName` value - either a `defaultResponses` key or a `CommandFamilies` key; `<name>.<variant>` targets a specific family variant (e.g. `socials.discord`). The dot-compound form is chat-input only - `name` and `variant` are split apart before reaching `CommandResponseService`, storage never holds dotted keys.
-* `add` creates a new response row. `<name>` must be a registered `CommandFamilies` name, and `<variant>` is required and cannot be empty - `add` cannot create a base/single-reponse entry.
-* `edit` updates an existing row - a family variant or a single-response command. Only commands with an existing reponse row are editable - anything else replies "does not have an editable text"
-* Text is trimmed and validated (length bounds); invalid text is rejected with a chat reply and the stored text is unchanged
+* `add` creates a new response row. `<name>` must be a registered `CommandFamilies` name, and `<variant>` is required and cannot be empty - `add` cannot create a base/single-response entry.
+* `edit` updates an existing row - a family variant or a single-response command. Only commands with an existing response row are editable - anything else replies "does not have an editable text"
+* `remove` soft-deletes an existing family variant row and evicts it from cache. `<variant>` is required and cannot be empty - baseline/single-response rows (`defaultResponses` entries) cannot be removed from chat.
+* A removed variant is gone from lookups and family listings (e.g. `!socials`) until restored. `add`-ing the same `<name>.<variant>` again un-deletes the row and overwrites its text with the newly supplied value, rather than failing with "already exists".
+* Text (`add`/`edit`) is trimmed and validated (length bounds); invalid text is rejected with a chat reply and the stored text is unchanged
 * A compound name with more than one dot (e.g. `a.b.c`) is rejected as an invalid command
-* Known behavior: a message missing the text entirely (`!command edit about`) does not match the pattern and is silently ignored
-* `remove` is not yet implemented - reponses can be added and edited, not deleted, from chat
+* A message missing its trailing text (e.g. `!command edit about`) still matches the pattern; `add`/`edit` reply with the generic invalid-input message rather than being silently ignored. `remove` never takes trailing text, so this doesn't apply to it.
 
 ### Reply Messages
 
 | Result | Verb | Reply |
 |---|---|---|
-| `invalidInput` | add, edit | Invalid input: both [name] and [text] are required |
+| `invalidInput` | add, edit, remove | Invalid input: both [name] and [text] are required |
 | `invalidText` | add, edit | Invalid text for command '\<name\>' |
 | `invalidCommandName` | add | Command \<name\> text family is not recognized |
 | `alreadyExists` | add | Command \<name\> text already exists |
@@ -163,6 +166,9 @@ Whether a `commandName` value resolves to a single fixed reponse or a family of 
 | `notEditable` | edit | Command \<name\> does not have an editable text |
 | `updated` | edit | Command \<name\> text was updated |
 | `updateFailed` | edit | Command \<name\> text failed to update |
+| `notFound` | remove | Command \<name\> was not found |
+| `removed` | remove | Command \<name\> was removed |
+| `removeFailed` | remove | Command \<name\> failed to be removed |
 
 ---
 

--- a/tests/common.mocks.ts
+++ b/tests/common.mocks.ts
@@ -24,4 +24,5 @@ export const mockCommandResponseService = <unknown>{
     addCommandText: jest.fn(),
     getCommandText: jest.fn(),
     setCommandText: jest.fn(),
+    removeCommandText: jest.fn(),
 } as jest.Mocked<CommandResponseService>;


### PR DESCRIPTION
## Summary
* Add `CommandResponse.removeCommandText`/`restoreCommandText` primitives (soft delete + restore-only lookup) to the dbo layer
* Add `CommandResponseService.removeCommandText`, and update `addCommandText` to restore-and-update a soft-deleted row instead of failing on the unique constraint
* Wire `!command remove <name>.<variant>` / `!cmd remove <name>.<variant>` into `ManageCommand`, fixing `exp` to accept the verb and make trailing text optional
* Document the `remove` verb, baseline-protection rule, and restore-on-add behavior in `docs/command-system.md`

Closes #123

## Test plan
- [x] `npm test` passes (integration suite spins up a real Postgres via testcontainers)
- [x] Manual: `!command remove <family>.<variant>` removes a variant and it disappears from lookups/listings
- [x] Manual: `!command add <family>.<variant> <text>` after a remove restores the row with the new text
- [x] Manual: `!command remove <name>` (baseline/no variant) is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
