### PR TITLE
Feature/132 restore verb for managecommand

### DIFF
--- a/bot/commands/manage.command.spec.ts
+++ b/bot/commands/manage.command.spec.ts
@@ -3,6 +3,7 @@ import { ChatUser } from '@twurple/chat';
 import ManageCommand, {
     InsertReplies,
     RemoveReplies,
+    RestoreReplies,
     UnsupportedMessage,
     UpdateReplies,
 } from './manage.command';
@@ -11,6 +12,7 @@ import {
     CommandTextInsertResult,
     CommandTextRemoveResult,
     CommandTextUpdateResult,
+    CommandTextRestoreResult,
 } from '../utilities/command-response.service';
 
 /** Utility method for constructing command message inline with ManageCommand */
@@ -71,11 +73,7 @@ describe('ManageCommand', () => {
                 const compoundName = 'Command.Variant';
                 const [name, variant] = compoundName.split('.');
                 const message = messageFn(subCommand, compoundName, text);
-                const args: any[] = [
-                    subCommand,
-                    compoundName,
-                    text,
-                ];
+                const args = parseComand(message, subject.exp);
 
                 mockCommandResponseService
                     .addCommandText
@@ -117,11 +115,7 @@ describe('ManageCommand', () => {
                 const compoundName = 'Command.Variant';
                 const [name, variant] = compoundName.split('.');
                 const message = messageFn(subCommand, compoundName, text);
-                const args: any[] = [
-                    subCommand,
-                    compoundName,
-                    text,
-                ];
+                const args = parseComand(message, subject.exp);
 
                 mockCommandResponseService
                     .setCommandText
@@ -163,11 +157,7 @@ describe('ManageCommand', () => {
                 const compoundName = 'Command.Variant';
                 const [name, variant] = compoundName.split('.');
                 const message = messageFn(subCommand, compoundName);
-                const args: any[] = [
-                    subCommand,
-                    compoundName,
-                    text,
-                ];
+                const args = parseComand(message, subject.exp);
 
                 mockCommandResponseService
                     .removeCommandText
@@ -190,6 +180,48 @@ describe('ManageCommand', () => {
 
             mockCommandResponseService
                 .removeCommandText
+                .mockRejectedValue(new Error('connection lost'));
+
+            // Act & Assert
+            await expect(subject.handle(channel, command, user, message, args))
+                .rejects.toThrow('connection lost');
+
+            expect(mockChatClient.say).not.toHaveBeenCalled();
+        });
+    });
+    describe('Restore Command', () => {
+        const subCommand = 'restore';
+
+        it.each(Object.keys(RestoreReplies) as CommandTextRestoreResult[])(
+            'replies correctly for %s result',
+            async result => {
+                // Arrange
+                const compoundName = 'Command.Variant';
+                const [name, variant] = compoundName.split('.');
+                const message = messageFn(subCommand, compoundName);
+                const args = parseComand(message, subject.exp);
+
+                mockCommandResponseService
+                    .restoreCommandText
+                    .mockResolvedValue(result);
+
+                // Act
+                await subject.handle(channel, command, user, message, args);
+
+                // Assert
+                expect(mockCommandResponseService.restoreCommandText)
+                    .toHaveBeenCalledWith(name, variant);
+                expect(mockChatClient.say).toHaveBeenCalledWith(channel, RestoreReplies[result](compoundName));
+            },
+        );
+
+        it('propagates unexpected service errors without replying', async () => {
+            // Arrange
+            const message = messageFn(subCommand, command, text);
+            const args = [subCommand, command, text];
+
+            mockCommandResponseService
+                .restoreCommandText
                 .mockRejectedValue(new Error('connection lost'));
 
             // Act & Assert

--- a/bot/commands/manage.command.ts
+++ b/bot/commands/manage.command.ts
@@ -8,6 +8,7 @@ import CommandResponseService, {
     CommandTextInsertResult,
     CommandTextUpdateResult,
     CommandTextRemoveResult,
+    CommandTextRestoreResult,
 } from '../utilities/command-response.service';
 
 export const GenericReplies: Record<CommandTextValidationResult, (name: string) => string> = {
@@ -36,6 +37,13 @@ export const RemoveReplies: Record<CommandTextRemoveResult, (name: string) => st
     removeFailed: name => `Command ${name} failed to be removed`,
 };
 
+export const RestoreReplies: Record<CommandTextRestoreResult, (name: string) => string> = {
+    ...GenericReplies,
+    notFound: name => `Command ${name} was not found`,
+    restored: name => `Command ${name} was restored`,
+    alreadyActive: name => `Command ${name} is already active`,
+};
+
 export const UnsupportedMessage = (name: string) => `${name} is not a valid command`;
 
 //
@@ -43,7 +51,7 @@ export const UnsupportedMessage = (name: string) => `${name} is not a valid comm
 //
 @injectable()
 export default class ManageCommand implements ICommandHandler {
-    exp: RegExp = /^!(command|cmd) (add|edit|remove) ([\w.]+)(?: (.+))?$/i;
+    exp: RegExp = /^!(command|cmd) (add|edit|remove|restore) ([\w.]+)(?: (.+))?$/i;
     timeout: number = 10;
     mod: boolean = true;
     vip: boolean = false;
@@ -84,6 +92,11 @@ export default class ManageCommand implements ICommandHandler {
                 case 'remove': {
                     const result = await this.commandResponseService.removeCommandText(name, variant);
                     this.chatClient.say(channel, RemoveReplies[result](compoundName));
+                    break;
+                }
+                case 'restore': {
+                    const result = await this.commandResponseService.restoreCommandText(name, variant);
+                    this.chatClient.say(channel, RestoreReplies[result](compoundName));
                     break;
                 }
             }

--- a/bot/utilities/command-response.service.spec.ts
+++ b/bot/utilities/command-response.service.spec.ts
@@ -7,6 +7,7 @@ import CommandResponseService, {
     CommandTextInsertResult,
     CommandTextUpdateResult,
     CommandTextRemoveResult,
+    CommandTextRestoreResult,
 } from './command-response.service';
 import { mockLogger } from '../../tests/common.mocks';
 import { defaultResponses } from './default-responses';
@@ -553,6 +554,81 @@ describe('CommandResponse.Service (postgres)', () => {
 
                 // Act & Assert
                 await expect(subject.removeCommandText(testCommand, testVariants[0]))
+                    .rejects.toThrow('connection lost');
+
+                spy.mockRestore();
+            });
+        });
+        describe('restoreCommandText()', () => {
+            it('should return false with empty commandName', async () => {
+                // Arrange - beforeEach()
+                // Act
+                const result = await subject.restoreCommandText('', 'ValidVariant');
+
+                // Assert
+                expect(result).toBe<CommandTextValidationResult>('invalidInput');
+            });
+            it('should return invalidInput with empty variant', async () => {
+                // Arrange - beforeEach()
+                // Act
+                const result = await subject.restoreCommandText(validName);
+
+                // Assert
+                expect(result).toBe<CommandTextValidationResult>('invalidInput');
+            });
+            it('should return alreadyActive when command/variant is present in cache', async () => {
+                // Arrange
+                await seedVariants(testCommand, testVariants);
+
+                // Act
+                const result = await subject.restoreCommandText(testCommand, testVariants[0]);
+                const variants = subject.getCommandVariants(testCommand);
+
+                // Assert
+                expect(result).toBe<CommandTextRestoreResult>('alreadyActive');
+                expect(variants.length).toBe(testVariants.length);
+                expect(variants).toContain(testVariants[0]);
+            });
+            it('should restore record in database records and cache (restored)', async () => {
+                // Arrange
+                await seedVariants(testCommand, testVariants);
+
+                // Act
+                const removed = await subject.removeCommandText(testCommand, testVariants[0]);
+                const result = await subject.restoreCommandText(testCommand, testVariants[0]);
+                const rows = await CommandResponse.findAll({ where: { commandName: testCommand } });
+                const variants = subject.getCommandVariants(testCommand);
+
+                // Assert
+                expect(removed).toBe<CommandTextRemoveResult>('removed');
+                expect(result).toBe<CommandTextRestoreResult>('restored');
+                expect(rows.length).toBe(testVariants.length);
+                expect(rows).toContainEqual(expect.objectContaining({ commandName: testCommand, variant: testVariants[0] }));
+                expect(variants.length).toBe(testVariants.length);
+                expect(variants).toContain(testVariants[0]);
+            });
+            it('should return notFound when command/variant is not in the database or cache', async () => {
+                // Arrange
+                await seedVariants(testCommand, [testVariants[0]]);
+
+                // Act
+                const result = await subject.restoreCommandText(testCommand, testVariants[1]);
+                const variants = subject.getCommandVariants(testCommand);
+
+                // Assert
+                expect(result).toBe<CommandTextRestoreResult>('notFound');
+                expect(variants.length).toBe(1);
+                expect(variants).not.toContain(testVariants[1]);
+            });
+            it('thrown error propagates', async () => {
+                // Arrange
+                await seedVariants(testCommand, testVariants);
+                const spy = jest.spyOn(CommandResponse, 'restoreCommandText')
+                    .mockRejectedValueOnce(new Error('connection lost'));
+
+                // Act & Assert
+                const removed = await subject.removeCommandText(testCommand, testVariants[0]);
+                await expect(subject.restoreCommandText(testCommand, testVariants[0]))
                     .rejects.toThrow('connection lost');
 
                 spy.mockRestore();

--- a/bot/utilities/command-response.service.ts
+++ b/bot/utilities/command-response.service.ts
@@ -24,6 +24,11 @@ export type CommandTextRemoveResult = CommandTextValidationResult |
     'removed' |
     'removeFailed';
 
+export type CommandTextRestoreResult = CommandTextValidationResult |
+    'notFound' |
+    'alreadyActive' |
+    'restored';
+
 type ResponseEntry = { variant: string; text: string };
 
 const cacheKey = (name: string, variant: string = ''): string => (variant ? `${name}.${variant}` : name);
@@ -90,7 +95,7 @@ export default class CommandResponseService {
         }
 
         try {
-            const restored = await CommandResponse.restoreCommandText(commandName, variant);
+            const [restored] = await CommandResponse.restoreCommandText(commandName, variant);
 
             if (restored) {
                 await CommandResponse.updateCommandText(commandName, text, variant);
@@ -172,5 +177,32 @@ export default class CommandResponseService {
 
         this.logger.warn(`Valid command (${cacheKey(commandName, variant)}) database remove attempt failed.`);
         return 'removeFailed';
+    }
+
+    /**
+     * Restore the command/variant from its soft-delete state
+     * @param commandName Command to restore
+     * @param variant The command variant to restore
+     * @returns boolean flag denoting if the provided command/variant was restored
+     */
+    async restoreCommandText(commandName: string, variant: string = ''): Promise<CommandTextRestoreResult> {
+        if (!commandName || !variant) {
+            return 'invalidInput';
+        }
+
+        if (!this.responseCache.has(cacheKey(commandName, variant))) {
+            const [restored, command] = await CommandResponse.restoreCommandText(commandName, variant);
+
+            if (restored && command) {
+                this.responseCache.set(cacheKey(command.commandName, command.variant), { variant: command.variant, text: command.text });
+                return 'restored';
+            }
+
+            if (!command) {
+                return 'notFound';
+            }
+        }
+
+        return 'alreadyActive';
     }
 }

--- a/database/models/command-response.dbo.ts
+++ b/database/models/command-response.dbo.ts
@@ -149,7 +149,7 @@ export default class CommandResponse extends Model {
      * @param variant The command name variant to restore
      * @returns boolean flag denoting if the provided command was restored
      */
-    static async restoreCommandText(commandName: string, variant: string = ''): Promise<boolean> {
+    static async restoreCommandText(commandName: string, variant: string = ''): Promise<[boolean, CommandResponse | null]> {
         const command = await CommandResponse
             .findOne({
                 where: {
@@ -168,9 +168,9 @@ export default class CommandResponse extends Model {
                     },
                 });
 
-            return true;
+            return [true, command];
         }
 
-        return false;
+        return [false, command];
     }
 }

--- a/docs/command-system.md
+++ b/docs/command-system.md
@@ -141,9 +141,11 @@ Whether a `commandName` value resolves to a single fixed reponse or a family of 
     !command add <name>[.<variant>] <text>
     !command edit <name>[.<variant>] <text>
     !command remove <name>.<variant>
+    !command restore <name>.<variant>
     !cmd add <name>[.<variant>] <text>
     !cmd edit <name>[.<variant>] <text>
     !cmd remove <name>.<variant>
+    !cmd restore <name>.<variant>
 
 * `<name>` is a `commandName` value - either a `defaultResponses` key or a `CommandFamilies` key; `<name>.<variant>` targets a specific family variant (e.g. `socials.discord`). The dot-compound form is chat-input only - `name` and `variant` are split apart before reaching `CommandResponseService`, storage never holds dotted keys.
 * `add` creates a new response row. `<name>` must be a registered `CommandFamilies` name, and `<variant>` is required and cannot be empty - `add` cannot create a base/single-response entry.
@@ -153,12 +155,13 @@ Whether a `commandName` value resolves to a single fixed reponse or a family of 
 * Text (`add`/`edit`) is trimmed and validated (length bounds); invalid text is rejected with a chat reply and the stored text is unchanged
 * A compound name with more than one dot (e.g. `a.b.c`) is rejected as an invalid command
 * A message missing its trailing text (e.g. `!command edit about`) still matches the pattern; `add`/`edit` reply with the generic invalid-input message rather than being silently ignored. `remove` never takes trailing text, so this doesn't apply to it.
+* `restore` un-deletes an existing soft-deleted family variant row and reinserts it into cache. `<variant>` is required and cannot be empty - baseline/single-response rows (`defaultResponses` entries) can never be soft-deleted from chat, so there's nothing for `restore` to act on.
 
 ### Reply Messages
 
 | Result | Verb | Reply |
 |---|---|---|
-| `invalidInput` | add, edit, remove | Invalid input: both [name] and [text] are required |
+| `invalidInput` | add, edit, remove, restore | Invalid input: both [name] and [text] are required |
 | `invalidText` | add, edit | Invalid text for command '\<name\>' |
 | `invalidCommandName` | add | Command \<name\> text family is not recognized |
 | `alreadyExists` | add | Command \<name\> text already exists |
@@ -169,6 +172,9 @@ Whether a `commandName` value resolves to a single fixed reponse or a family of 
 | `notFound` | remove | Command \<name\> was not found |
 | `removed` | remove | Command \<name\> was removed |
 | `removeFailed` | remove | Command \<name\> failed to be removed |
+| `notFound` | restore | Command \<name\> was not found |
+| `alreadyActive` | restore | Command \<name\> is already active |
+| `restored` | restore | Command \<name\> was restored |
 
 ---
 

--- a/tests/common.mocks.ts
+++ b/tests/common.mocks.ts
@@ -25,4 +25,5 @@ export const mockCommandResponseService = <unknown>{
     getCommandText: jest.fn(),
     setCommandText: jest.fn(),
     removeCommandText: jest.fn(),
+    restoreCommandText: jest.fn(),
 } as jest.Mocked<CommandResponseService>;


### PR DESCRIPTION
## Summary
* Widen `CommandResponse.restoreCommandText` (dbo) to return `[boolean, CommandResponse | null]`, exposing the row it already fetches so callers can distinguish not-found from already-active
* Add `CommandResponseService.restoreCommandText` and `CommandTextRestoreResult` (`notFound` | `alreadyActive` | `restored`)
* Wire `!command restore <name>.<variant>` / `!cmd restore <name>.<variant>` into `ManageCommand`, adding the verb to `exp` and a `RestoreReplies` reply map
* Document the `restore` verb in `docs/command-system.md`

Closes #132

## Test plan
- [x] `npm test` passes (integration suite spins up a real Postgres via testcontainers)
- [x] Manual: `!command restore <family>.<variant>` on a removed variant restores it and it reappears in lookups/listings
- [x] Manual: `!command restore <family>.<variant>` on an already-active variant replies "already active" without touching the DB
- [x] Manual: `!command restore <family>.<variant>` on a name that was never created replies "not found"
- [x] Manual: `!command restore <name>` (baseline/no variant) is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
