### PR TITLE
chore(skills): add github-pr-create and create-work-checklist Claude Code skills (#135)

### DIFF
--- a/.claude/skills/create-work-checklist/SKILL.md
+++ b/.claude/skills/create-work-checklist/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: create-work-checklist
+description: Create a per-file implementation outline for a GitHub issue at .claude/tmp/issue-<number>/outline.md. Use when asked to plan, scope, or break down an issue before implementation.
+---
+
+# Create Work Checklist
+
+Produces `.claude/tmp/issue-<number>/outline.md` - a file-by-file implementation plan for a GitHub issue, written after reading both the issue and the current state of the affected code. `.claude/tmp/` is a local, gitignored scratch space, not team-shared.
+
+## Issue ID
+
+* **Condition 1** - user provides the issue ID (argument or conversation): use it directly
+* **Condition 2** - user doesn't provide it, current branch isn't the default branch: extract the issue number from the branch name, ask the user to confirm via AskUserQuestion (branch-derived ID or Cancel; free text always available for a different number)
+* **Condition 3** - user doesn't provide it, current branch is the default branch: nothing to derive - ask via AskUserQuestion, offering the top 4 results of `gh issue list --state open --search "sort:updated-desc" --limit 5` as quick picks (free-text always available for anything else)
+
+Selecting Cancel stops the workflow - no outline is written.
+
+Every ask in this section uses AskUserQuestion - never a plain conversational question. A plain response doesn't reliably signal that the workflow is blocked waiting on required input.
+
+## Errors
+
+* Issue not found (404) - report it, stop. No retry, no guessing at a different number.
+* Any other failure (API error including 5xx/protocol-level responses, tool permission, CLI permission, network) - report it to the user, stop, let them decide how to proceed
+
+## Workflow
+
+1. Get the issue ID, if not provided
+2. Read the issue
+3. Identify affected files - from the issue's own text and by exploring the codebase directly
+4. Read those files to confirm current state
+5. If something the issue doesn't resolve turns up, ask before writing
+6. Write `outline.md` following the Structure below
+
+## Structure
+
+```
+# Issue #<N> outline - <short description>
+
+<Depends on / Blocks: #M (...)>
+
+## Decisions locked
+
+* <settled scoping decision, with rationale>
+
+## 1. <file path>
+
+* <specific change: function/method, signature, behavior>
+
+<optional: state table, only when this specific file's logic warrants one>
+
+## 2. <file path>
+
+...
+
+## <N>. Tests
+
+* <spec file>: <test case>, <test case>, ...
+
+## <N>. docs/<file>
+
+* <specific doc update>
+```
+
+## Sections
+
+* **Title** - always present: `# Issue #<N> outline - <short description>`
+* **Relationship line** - only when the issue depends on or blocks another issue; sourced from the issue's own title/label
+* **Decisions locked** - only when this issue has open scoping decisions to work through with the user before execution; not retained once resolved
+* **Numbered file sections** - one per affected file, ordered by dependency layer (foundational/lowest-level file first, working up toward the user-facing surface); no line numbers; a state table only when that file's logic warrants one
+* **Tests section** - always present, listing affected spec files and terse test-case names
+* **Docs section** - present when documentation needs updating
+
+## Rules
+
+* Every file-level claim (function names, signatures, behavior) comes from a file actually read this session - never guessed
+* Numbered sections contain only actionable work - no narration of what's excluded or unchanged
+* Writing `outline.md` is destructive - a pre-existing file at that path is never read; the new file is composed fresh from the issue and code, not the old version

--- a/.claude/skills/github-pr-create/SKILL.md
+++ b/.claude/skills/github-pr-create/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: github-pr-create
+description: Create a GitHub pull request via gh CLI, deriving a Conventional-Commits-style title from the branch's commits and its source issue. Use when asked to create/open a PR, or to run gh pr create.
+---
+
+# GitHub PR Create
+
+Creates a pull request via `gh pr create` for the current branch.
+
+## Workflow
+
+1. Read the issue tied to the branch
+2. Score the branch's commits to determine type
+3. Resolve scope (ask if a candidate is found)
+4. Resolve milestone, assignee, base, reviewer, draft (fixed or issue-derived rules)
+5. Resolve project (use directly if the issue has exactly one, otherwise ask)
+6. Compute labels as the union of the issue's labels and deduced commit-type labels
+7. Compose the body
+8. Run `gh pr create` with the computed values
+
+## Rules
+
+* Every computed value (type, scope match, labels) comes from data actually read this session - never guessed
+* Any ask uses AskUserQuestion - never a plain conversational question
+
+## Title
+
+Format: `type(scope): issue title (#N)` - scope segment omitted when it doesn't clear the bar.
+
+### Type
+
+Score every commit unique to the branch relative to the repo's default branch (`git log <default-branch>..HEAD`) by type; take the highest-ranked type present:
+
+```
+feat > fix > refactor/perf > docs > test > build/ci > chore > style
+```
+
+Every commit counts, including ones that don't follow Conventional Commits syntax - a commit without a recognized `type(scope):`/`type:` prefix is treated as the lowest tier (`style`), never excluded.
+
+### Scope
+
+Candidates come only from the issue's title (headline/parenthetical order) and whichever prose section the issue opens with (a `Goal` line, or the opening of `Context`/`Decisions`). `Scope`/`Work` checklists are never used. A commit is only a scope candidate if its scope token matches a name from the title or opening prose - matching is case-insensitive and ignores non-alphanumeric characters (`CommandResponse` and `command-response` match).
+
+* **Absent** - no named candidates -> omit scope, no question
+* **Single** - exactly one named candidate -> use it directly, no question
+* **Multiple** - more than one named candidate -> ask the user, show what was found, use exactly what they type
+
+### Description
+
+The issue title, with only the first letter lowercased - rest of the title unchanged (preserves proper nouns and identifiers like `CommandResponse` or `Claude Code`).
+
+## Base
+
+Never set - omit `--base` and let `gh pr create` use its own default.
+
+## Milestone
+
+The issue's milestone, if it has one. Left unset otherwise.
+
+## Assignee
+
+Always the command invoker - `gh`'s `@me` alias (the currently authenticated user), never a fixed name.
+
+## Reviewer
+
+Never set.
+
+## Draft
+
+Never set.
+
+## Project
+
+Check the issue's own project membership (`projectItems`). Exactly one -> use it directly. Zero, or more than one -> ask the user (offer any found candidates as quick picks; free text for anything else).
+
+## Labels
+
+Union of:
+
+* The issue's own labels
+* Labels deduced from the commit types present on the branch, mapped as:
+  * `feat` -> `enhancement`
+  * `fix` -> `bug`
+  * `docs` -> `documentation`
+  * `test` -> `Testing`
+  * `build` -> `dependencies`
+
+A commit type with no mapped label (`refactor`, `perf`, `ci`, `chore`, `style`) doesn't add one.
+
+## Body
+
+Template:
+
+```
+## Summary
+
+* <bullet: specific change>
+* <bullet: specific change>
+
+Closes #<N>
+
+## Commits
+
+* <commit 1 subject>
+* <commit 2 subject>
+
+## Verification Steps
+
+- [ ] <verification step>
+```
+
+`## Commits` lists the branch's commit subjects verbatim (GitHub's own default multi-commit format) - the full per-commit body detail already survives in the squash commit on `main`, so it isn't duplicated here.
+
+`## Verification Steps` calls out `npm run lint` and `npm test` specifically when the branch includes a code change (any commit type other than `docs`, `chore`, or `style`), plus additional verification steps specific to the work actually done on the branch.
+
+No footer line - nothing is appended to attribute PR authorship to a tool.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- What changed and why. One bullet per notable change. -->
+
+*
+
+Closes # <!-- Issue Number -->
+
+## Commits
+
+<!-- Commit subjects for this branch, verbatim. GitHub already lists these on the Commits tab, but squash merge collapses them out of main's everyday log, so repeating them here keeps them visible on the PR description.
+
+* feat(example-feature): add new feature
+
+-->
+
+* <!-- Commit Title -->
+
+## Verification Steps
+
+<!-- Uncomment the checks below if this PR includes a code change -->
+<!-- - [ ] `npm run lint` -->
+<!-- - [ ] `npm test` -->
+

--- a/.github/git-type-conventions.md
+++ b/.github/git-type-conventions.md
@@ -1,0 +1,24 @@
+# Type Conventions
+
+Commit messages and branch names share one type vocabulary (Conventional Commits).
+
+| Type | Use for |
+|---|---|
+| `feat` | New functionality for the shipped product |
+| `fix` | Bug fixes |
+| `refactor` | Internal restructuring, no behavior change |
+| `perf` | Performance improvements |
+| `docs` | Documentation-only changes |
+| `test` | Test-only changes |
+| `build` | Build system, dependencies, packaging |
+| `ci` | CI/CD pipeline changes |
+| `chore` | Tooling, maintenance, process - no product or build impact |
+| `style` | Formatting/whitespace only, no logic change |
+
+## Commits
+
+`type(scope): description` - scope is the affected area (e.g. `manage-command`, `command-response`).
+
+## Branches
+
+`type/<issue-id>-slug`


### PR DESCRIPTION
## Summary

* Add `github-pr-create` skill to derive PR title/labels/body from the source issue and branch commits
* Add `create-work-checklist` skill to produce `.claude/tmp/issue-<number>/outline.md` implementation plans
* Add `.github/PULL_REQUEST_TEMPLATE.md` for manual PR descriptions
* Add `.github/git-type-conventions.md` documenting the shared commit/branch type vocabulary

Closes #135

## Commits

* chore(skills): add pr-create and checklist skills

## Verification Steps

- [x] Manually run `/create-work-checklist` and `/github-pr-create` end to end and confirm output