### PR TITLE
fix(accountage): fix context to include `targetuser`

### DIFF
--- a/bot/commands/accountAgeCommand.spec.ts
+++ b/bot/commands/accountAgeCommand.spec.ts
@@ -50,7 +50,7 @@ describe('Account Age Command Tests', () => {
 
             mockCommandResponseService
                 .getCommandText
-                .mockReturnValue(`%${transientKeywords.speakinguser}%, %${transientKeywords.accountage}%`);
+                .mockReturnValue(`%${transientKeywords.targetuser}%, %${transientKeywords.accountage}%`);
 
             const age = getAgeReport(Timespan.fromNow(targetUser.creationDate));
 
@@ -85,7 +85,7 @@ describe('Account Age Command Tests', () => {
 
             mockCommandResponseService
                 .getCommandText
-                .mockReturnValue(`%${transientKeywords.speakinguser}%, %${transientKeywords.accountage}%`);
+                .mockReturnValue(`%${transientKeywords.targetuser}%, %${transientKeywords.accountage}%`);
 
             const age = getAgeReport(Timespan.fromNow(targetUser.creationDate));
 

--- a/bot/commands/accountAgeCommand.ts
+++ b/bot/commands/accountAgeCommand.ts
@@ -44,7 +44,7 @@ export class AccountAgeCommand implements ICommandHandler {
 
             if (result) {
                 const context: TransientContext = {
-                    speakinguser: user.displayName,
+                    targetuser: user.displayName,
                     accountage: `${getAgeReport(Timespan.fromNow(user.creationDate))}`,
                 };
 


### PR DESCRIPTION
## Summary

* Fix `AccountAgeCommand`'s `TransientContext` to populate `targetuser` instead of `speakinguser`, matching `defaultResponses.accountage`'s `%targetuser%` template token
* Update `accountAgeCommand.spec.ts`'s mocked response templates to reference `%targetuser%` accordingly

## Commits

* fix(accountage): fix context to include `targetuser`

## Verification Steps

- [x] `npm run lint`
- [x] `npm test`
- [x] Manually run `!accountage` (self and with a target username) in a live or test channel and confirm the response no longer shows the literal `%targetuser%` token
