### PR TITLE
fix: resolve concurrency deadlock across chained GitHub Actions workflows

### DIFF
--- a/.claude/skills/github-pr-create/SKILL.md
+++ b/.claude/skills/github-pr-create/SKILL.md
@@ -12,7 +12,7 @@ Creates a pull request via `gh pr create` for the current branch.
 1. Read the issue tied to the branch
 2. Score the branch's commits to determine type
 3. Resolve scope (ask if a candidate is found)
-4. Resolve milestone, assignee, base, reviewer, draft (fixed or issue-derived rules)
+4. Resolve milestone, assignee, base, reviewer, draft (fixed or issue-derived rules; ask if no issue is tied to the branch)
 5. Resolve project (use directly if the issue has exactly one, otherwise ask)
 6. Compute labels as the union of the issue's labels and deduced commit-type labels
 7. Compose the body
@@ -57,6 +57,8 @@ Never set - omit `--base` and let `gh pr create` use its own default.
 
 The issue's milestone, if it has one. Left unset otherwise.
 
+No issue tied to the branch -> fetch the repo's open milestones (`gh api repos/{owner}/{repo}/milestones`) and ask the user, offering the titles as quick picks plus a "skip" option.
+
 ## Assignee
 
 Always the command invoker - `gh`'s `@me` alias (the currently authenticated user), never a fixed name.
@@ -72,6 +74,8 @@ Never set.
 ## Project
 
 Check the issue's own project membership (`projectItems`). Exactly one -> use it directly. Zero, or more than one -> ask the user (offer any found candidates as quick picks; free text for anything else).
+
+No issue tied to the branch -> fetch the repo's projects (`gh project list --owner <owner>`) and ask the user, offering the titles as quick picks plus a "skip" option.
 
 ## Labels
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
     contents: read
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
+    group: ${{ github.workflow_ref }}
     cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -27,7 +27,7 @@ permissions:
     contents: read
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
+    group: ${{ github.workflow_ref }}
     cancel-in-progress: true
 
 env:

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -39,7 +39,7 @@ permissions:
     contents: write
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
+    group: ${{ github.workflow_ref }}
     cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

* Fix the concurrency-group deadlock across `ci.yml`, `docker-build.yml`, and `tag-version.yml` by switching their group keys to `${{ github.workflow_ref }}`, which stays tied to each workflow's own file regardless of caller, unlike `${{ github.workflow }}` which resolves to the calling workflow's name when invoked as a reusable workflow
* Update the `github-pr-create` skill to ask for a milestone/project via quick-pick options when no issue is tied to the branch, instead of silently leaving them unset

## Commits

* fix(ci): Correct concurrenty on chainable gh-actions
* chore(skill): Update  skill to ask for project and milestone

## Verification Steps

- [x] `npm run lint`
- [x] `npm test`
- [ ] Trigger the `Full Release` workflow with `dry_run: true` and confirm it no longer cancels with a concurrency deadlock
